### PR TITLE
feat!: new finders API & performance improvements

### DIFF
--- a/libraries/app/src/components/ErrorBoundaryScreen.tsx
+++ b/libraries/app/src/components/ErrorBoundaryScreen.tsx
@@ -31,8 +31,10 @@ const styles = StyleSheet.create({
     },
 })
 
+type PossibleRenderError = Error & { componentStack?: string }
+
 export default function ErrorBoundaryScreen(props: {
-    error: (Error & { componentStack?: string }) | unknown
+    error: PossibleRenderError | unknown
     rerender: () => void
     reload: () => void
 }) {
@@ -92,16 +94,16 @@ export default function ErrorBoundaryScreen(props: {
                     </>
                 )}
             </LabeledCard>
-            {error instanceof Error && 'componentStack' in error && (
+            {error instanceof Error && (error as PossibleRenderError).componentStack && (
                 <LabeledCard
                     scrollable
                     label="Component Stack"
                     style={styles.resizable}
-                    rawContent={error.componentStack as string}
+                    rawContent={(error as PossibleRenderError).componentStack!}
                 >
                     <Text selectable variant="text-md/medium">
-                        {...(error.componentStack as string)
-                            .slice(1)
+                        {...(error as PossibleRenderError)
+                            .componentStack!.slice(1)
                             .split('\n')
                             // biome-ignore lint/correctness/useJsxKeyInIterable: This never gets rerendered
                             .map(line => ['<', <Text variant="text-md/bold">{line.slice(7)}</Text>, '/>\n'])}

--- a/libraries/app/src/index.tsx
+++ b/libraries/app/src/index.tsx
@@ -1,5 +1,6 @@
 import { React, ReactNative } from '@revenge-mod/modules/common'
-import { findByName } from '@revenge-mod/modules/finders'
+import { byName } from '@revenge-mod/modules/filters'
+import { findAsync } from '@revenge-mod/modules/finders'
 import { BundleUpdaterManager } from '@revenge-mod/modules/native'
 import { createPatcherInstance } from '@revenge-mod/patcher'
 import { ReactJSXLibrary } from '@revenge-mod/react/jsx'
@@ -70,9 +71,9 @@ afterErrorBoundaryPatchable(async function patchErrorBoundary() {
 
     setImmediate(() => {
         patcher.after.await(
-            findByName
-                .async('ErrorBoundary')
-                .then(it => (it as { name: string; prototype: ErrorBoundaryComponentPrototype }).prototype),
+            findAsync(byName<{ name: string; prototype: ErrorBoundaryComponentPrototype }>('ErrorBoundary')).then(
+                it => it!.prototype,
+            ),
             'render',
             function () {
                 if (this.state.error)

--- a/libraries/app/src/index.tsx
+++ b/libraries/app/src/index.tsx
@@ -69,13 +69,10 @@ afterErrorBoundaryPatchable(async function patchErrorBoundary() {
 
     const { default: Screen } = await import('./components/ErrorBoundaryScreen')
 
-    setImmediate(() => {
-        patcher.after.await(
-            findAsync(byName<{ prototype: ErrorBoundaryComponentPrototype }>('ErrorBoundary')).then(
-                it => it!.prototype,
-            ),
-            'render',
-            function () {
+    setImmediate(() =>
+        findAsync(byName<{ prototype: ErrorBoundaryComponentPrototype }>('ErrorBoundary')).then(it => {
+            const origRender = it!.prototype.render
+            it!.prototype.render = function render() {
                 if (this.state.error)
                     return (
                         <Screen
@@ -84,12 +81,13 @@ afterErrorBoundaryPatchable(async function patchErrorBoundary() {
                             reload={this.handleReload}
                         />
                     )
-            },
-            'patchErrorBoundary',
-        )
 
-        logger.log('ErrorBoundary patched')
-    })
+                return origRender.call(this)
+            }
+
+            logger.log('ErrorBoundary patched')
+        }),
+    )
 })
 
 export const AppLibrary = {

--- a/libraries/app/src/index.tsx
+++ b/libraries/app/src/index.tsx
@@ -71,7 +71,7 @@ afterErrorBoundaryPatchable(async function patchErrorBoundary() {
 
     setImmediate(() => {
         patcher.after.await(
-            findAsync(byName<{ name: string; prototype: ErrorBoundaryComponentPrototype }>('ErrorBoundary')).then(
+            findAsync(byName<{ prototype: ErrorBoundaryComponentPrototype }>('ErrorBoundary')).then(
                 it => it!.prototype,
             ),
             'render',

--- a/libraries/app/src/index.tsx
+++ b/libraries/app/src/index.tsx
@@ -3,15 +3,12 @@ import { byName } from '@revenge-mod/modules/filters'
 import { findAsync } from '@revenge-mod/modules/finders'
 import { BundleUpdaterManager } from '@revenge-mod/modules/native'
 import { createPatcherInstance } from '@revenge-mod/patcher'
-import { ReactJSXLibrary } from '@revenge-mod/react/jsx'
 import { createLogger } from '@revenge-mod/utils/library'
 
 import type { Component, FC, ReactNode } from 'react'
 
 const patcher = createPatcherInstance('revenge.library.app')
 const logger = createLogger('app')
-
-logger.log('Library loaded')
 
 const initializeCallbacks = new Set<AppGenericCallback>()
 const renderCallbacks = new Set<AppGenericCallback>()
@@ -38,7 +35,6 @@ const unpatchRunApplication = patcher.after(
     () => {
         unpatchRunApplication()
 
-        logger.log('AppRegistry.runApplication called')
         for (const callback of initializeCallbacks) callback()
         logger.log('Initialized callbacks called')
     },
@@ -51,43 +47,31 @@ const unpatchCreateElement = patcher.after(
     () => {
         unpatchCreateElement()
 
-        logger.log('React.createElement called')
         for (const callback of renderCallbacks) callback()
         logger.log('Rendered callbacks called')
     },
     'runRenderCallbacks',
 )
 
-const afterErrorBoundaryPatchable = ReactNative.Platform.OS === 'ios' ? afterAppRender : afterAppInitialize
-
-afterErrorBoundaryPatchable(async function patchErrorBoundary() {
-    // Patching ErrorBoundary causes the weird "Element type is invalid" error due to TextInputWrapper's children being undefined
-    // The reason for it being undefined is unknown, but it's not a problem on Android
-    // Using this patch on Android also breaks how the chat input bar avoids the keyboard
-    if (ReactNative.Platform.OS === 'ios')
-        ReactJSXLibrary.afterElementCreate('PortalKeyboardPlaceholderInner', () => null)
-
+afterAppInitialize(async () => {
     const { default: Screen } = await import('./components/ErrorBoundaryScreen')
+    const ErrorBoundary = (await findAsync(byName<{ prototype: ErrorBoundaryComponentPrototype }>('ErrorBoundary')))!
 
-    setImmediate(() =>
-        findAsync(byName<{ prototype: ErrorBoundaryComponentPrototype }>('ErrorBoundary')).then(it => {
-            const origRender = it!.prototype.render
-            it!.prototype.render = function render() {
-                if (this.state.error)
-                    return (
-                        <Screen
-                            error={this.state.error}
-                            rerender={() => this.setState({ error: null, info: null })}
-                            reload={this.handleReload}
-                        />
-                    )
+    const origRender = ErrorBoundary.prototype.render
+    ErrorBoundary.prototype.render = function() {
+        if (this.state.error)
+            return (
+                <Screen
+                    error={this.state.error}
+                    rerender={() => this.setState({ error: null, info: null })}
+                    reload={this.handleReload}
+                />
+            )
 
-                return origRender.call(this)
-            }
+        return origRender.call(this)
+    }
 
-            logger.log('ErrorBoundary patched')
-        }),
-    )
+    logger.log('ErrorBoundary patched')
 })
 
 export const AppLibrary = {
@@ -128,7 +112,6 @@ export type ErrorBoundaryComponentPrototype = Component<
         info: { componentStack?: string } | null
     }
 > & {
-    name: 'ErrorBoundary'
     discordErrorsSet: boolean
     handleReload(): void
 }

--- a/libraries/assets/src/index.ts
+++ b/libraries/assets/src/index.ts
@@ -1,6 +1,9 @@
 import { assetsRegistry } from '@revenge-mod/modules/common'
-import { findByName } from '@revenge-mod/modules/finders'
+
+import { byName } from '@revenge-mod/modules/filters'
+import { findAsync } from '@revenge-mod/modules/finders'
 import { getImportingModuleId, requireModule } from '@revenge-mod/modules/metro'
+
 import { createPatcherInstance } from '@revenge-mod/patcher'
 
 import { cache, cacheAsset } from '@revenge-mod/modules/metro/caches'
@@ -42,7 +45,7 @@ type AssetSourceResolver = {
     }
 }
 
-const AssetSourceResolver = findByName.async<AssetSourceResolver, true>('AssetSourceResolver').then(it => it!.prototype)
+const AssetSourceResolver = findAsync(byName<AssetSourceResolver>('AssetSourceResolver')).then(it => it!.prototype)
 
 function maybeResolveCustomAsset(
     this: AssetSourceResolver['prototype'],
@@ -137,7 +140,7 @@ export function getAssetIndexByName(name: string, preferredType: PackagerAsset['
     if (!assetModule) return
 
     const mid = assetModule[preferredType] ?? assetModule[getFirstRegisteredAssetTypeByName(name)!]
-    if (typeof mid === 'undefined') return
+    if (typeof mid !== 'number') return
 
     return requireModule(mid)
 }

--- a/libraries/assets/src/index.ts
+++ b/libraries/assets/src/index.ts
@@ -9,8 +9,9 @@ import { createPatcherInstance } from '@revenge-mod/patcher'
 import { cache, cacheAsset } from '@revenge-mod/modules/metro/caches'
 import { FirstAssetTypeRegisteredKey, assetCacheIndexSymbol } from '@revenge-mod/modules/constants'
 
+import { Platform, type ImageSourcePropType } from 'react-native'
+
 import type { ReactNativeInternals } from '@revenge-mod/revenge'
-import type { ImageSourcePropType } from 'react-native'
 
 const patcher = createPatcherInstance('revenge.library.assets')
 
@@ -23,15 +24,14 @@ type CustomAsset = PackagerAsset & {
     [CustomAssetBrandKey]: string
 }
 
-let defaultPreferredType: PackagerAsset['type'] = ReactNative.Platform.OS === 'ios' ? 'png' : 'svg'
+let defaultPreferredType: PackagerAsset['type'] = Platform.OS === 'ios' ? 'png' : 'svg'
 
 patcher.after(
     assetsRegistry,
     'registerAsset',
     ([asset], index) => {
         if ((asset as CustomAsset)[CustomAssetBrandKey]) return
-        const moduleId = getImportingModuleId()
-        cacheAsset(asset.name, index, moduleId, asset.type)
+        cacheAsset(asset.name, index, getImportingModuleId()!, asset.type)
     },
     'patchRegisterAsset',
 )

--- a/libraries/modules/src/common/components/index.ts
+++ b/libraries/modules/src/common/components/index.ts
@@ -1,14 +1,16 @@
 import { lazyDestructure } from '@revenge-mod/utils/lazy'
-import { findByProps, findProp, findSingleProp } from '../../finders'
 
-import type { DiscordModules } from '../../types'
+import { findEager, findProp, findSingleProp } from '@revenge-mod/modules/finders'
+import { byProps } from '@revenge-mod/modules/filters'
 
 export * as Icons from './icons'
 
+import type { DiscordModules } from '../../types'
+
 // React Native's included SafeAreaView only adds padding on iOS.
 export const { SafeAreaProvider, SafeAreaView } = lazyDestructure(
-    () => findByProps.eager('useSafeAreaInsets')!,
-) as typeof import('react-native-safe-area-context')
+    () => findEager(byProps<typeof import('react-native-safe-area-context')>('useSafeAreaInsets'))!,
+)
 
 /// DISCORD
 
@@ -67,43 +69,45 @@ export const {
     Text,
 } = lazyDestructure(
     () =>
-        findByProps.eager<{
-            Text: DiscordModules.Components.Text
+        findEager(
+            byProps<{
+                Text: DiscordModules.Components.Text
 
-            TextInput: DiscordModules.Components.TextInput
-            TextField: DiscordModules.Components.TextField
-            TextArea: DiscordModules.Components.TextArea
-            GhostInput: DiscordModules.Components.GhostInput
+                TextInput: DiscordModules.Components.TextInput
+                TextField: DiscordModules.Components.TextField
+                TextArea: DiscordModules.Components.TextArea
+                GhostInput: DiscordModules.Components.GhostInput
 
-            ActionSheet: DiscordModules.Components.ActionSheet
-            ActionSheetCloseButton: DiscordModules.Components.ActionSheetCloseButton
-            ActionSheetRow: DiscordModules.Components.ActionSheetRow
+                ActionSheet: DiscordModules.Components.ActionSheet
+                ActionSheetCloseButton: DiscordModules.Components.ActionSheetCloseButton
+                ActionSheetRow: DiscordModules.Components.ActionSheetRow
 
-            Button: DiscordModules.Components.Button
-            IconButton: DiscordModules.Components.IconButton
-            ImageButton: DiscordModules.Components.ImageButton
-            FloatingActionButton: DiscordModules.Components.FloatingActionButton
-            RowButton: DiscordModules.Components.RowButton
+                Button: DiscordModules.Components.Button
+                IconButton: DiscordModules.Components.IconButton
+                ImageButton: DiscordModules.Components.ImageButton
+                FloatingActionButton: DiscordModules.Components.FloatingActionButton
+                RowButton: DiscordModules.Components.RowButton
 
-            ContextMenu: DiscordModules.Components.ContextMenu
+                ContextMenu: DiscordModules.Components.ContextMenu
 
-            TableRow: DiscordModules.Components.TableRow
-            TableSwitchRow: DiscordModules.Components.TableSwitchRow
-            TableRowGroup: DiscordModules.Components.TableRowGroup
-            TableRowGroupTitle: DiscordModules.Components.TableRowGroupTitle
-            TableRowIcon: DiscordModules.Components.TableRowIcon
-            TableRadioGroup: DiscordModules.Components.TableRadioGroup
-            TableCheckboxRow: DiscordModules.Components.TableCheckboxRow
-            TableRadioRow: DiscordModules.Components.TableRadioRow
+                TableRow: DiscordModules.Components.TableRow
+                TableSwitchRow: DiscordModules.Components.TableSwitchRow
+                TableRowGroup: DiscordModules.Components.TableRowGroup
+                TableRowGroupTitle: DiscordModules.Components.TableRowGroupTitle
+                TableRowIcon: DiscordModules.Components.TableRowIcon
+                TableRadioGroup: DiscordModules.Components.TableRadioGroup
+                TableCheckboxRow: DiscordModules.Components.TableCheckboxRow
+                TableRadioRow: DiscordModules.Components.TableRadioRow
 
-            AlertModal: DiscordModules.Components.AlertModal
-            AlertActionButton: DiscordModules.Components.AlertActionButton
+                AlertModal: DiscordModules.Components.AlertModal
+                AlertActionButton: DiscordModules.Components.AlertActionButton
 
-            Card: DiscordModules.Components.Card
-            Stack: DiscordModules.Components.Stack
+                Card: DiscordModules.Components.Card
+                Stack: DiscordModules.Components.Stack
 
-            Slider: DiscordModules.Components.Slider
-        }>('TextField', 'ContextMenu')!,
+                Slider: DiscordModules.Components.Slider
+            }>('TextField', 'ContextMenu'),
+        )!,
 )
 
 export const IntlLink = findProp<DiscordModules.Components.IntlLink>('IntlLink')!
@@ -121,5 +125,5 @@ export const FormRadio = findSingleProp<DiscordModules.Components.FormRadio>('Fo
 export const FormCheckbox = findSingleProp<DiscordModules.Components.FormCheckbox>('FormCheckbox')!
 
 export const { FlashList, MasonryFlashList } = lazyDestructure(
-    () => findByProps.eager<typeof import('@shopify/flash-list')>('FlashList')!,
+    () => findEager(byProps<typeof import('@shopify/flash-list')>('FlashList'))!,
 )

--- a/libraries/modules/src/common/index.ts
+++ b/libraries/modules/src/common/index.ts
@@ -1,5 +1,4 @@
 import { lazyDestructure, lazyValue } from '@revenge-mod/utils/lazy'
-import { findByFilePath, findByName, findByProps, findSingleProp } from '../finders'
 
 import React from 'react'
 import ReactNative from 'react-native'
@@ -7,56 +6,60 @@ import ReactNative from 'react-native'
 import type { ReactNativeInternals } from '@revenge-mod/revenge'
 import type { DiscordModules } from '../types'
 
+import { byFilePath, byName, byProps } from '@revenge-mod/modules/filters'
+import { find, findEager, findSingleProp } from '../finders'
+
 export * as components from './components'
 export * as stores from './stores'
 
 /// DISCORD
 
-export const constants = findByProps<Record<string, unknown>>('Fonts')!
-export const tokens = findByProps('internal', 'colors')!
-export const intl = findByProps<{
-    intl: import('@discord/intl').IntlManager & {
-        format: typeof import('@discord/intl').astFormatter['format']
-        formatToPlainString: typeof import('@discord/intl').stringFormatter['format']
-        formatToMarkdownString: typeof import('@discord/intl').markdownFormatter['format']
-        formatToParts: typeof import('@discord/intl').reactFormatter['format']
-    }
-    t: Record<
-        string,
-        (() => {
-            locale: string
-            /**
-             * Keyless AST structure
-             * @see Android's `base.apk/res/raw/intl_messages_*.jsona`
-             * @see {@link https://github.com/discord/discord-intl/blob/main/packages/intl-ast/index.ts}
-             */
-            ast: string | import('@discord/intl-ast').AstNode[]
-            reserialize(): string
-        }) & {
-            __phantom: unknown
+export const constants = find(byProps<Record<string, unknown>>('Fonts'))!
+export const tokens = find(byProps('internal', 'colors'))!
+export const intl = find(
+    byProps<{
+        intl: import('@discord/intl').IntlManager & {
+            format: typeof import('@discord/intl').astFormatter['format']
+            formatToPlainString: typeof import('@discord/intl').stringFormatter['format']
+            formatToMarkdownString: typeof import('@discord/intl').markdownFormatter['format']
+            formatToParts: typeof import('@discord/intl').reactFormatter['format']
         }
-    >
-}>('intl')!
-export const intlModule = findByProps<typeof import('@discord/intl')>('runtimeHashMessageKey')!
-
-export const Logger = findByName<typeof DiscordModules.Logger, true>('Logger')!
-
-export const actionSheets = findByProps<DiscordModules.ActionSheets>('hideActionSheet')!
-export const alerts = findByProps<DiscordModules.Alerts>('openAlert', 'dismissAlert')!
-export const channels = findByProps('getVoiceChannelId')!
-export const links = findByProps<DiscordModules.LinkingUtils>('openURL', 'openDeeplink')!
-export const clipboard = findByProps<DiscordModules.ClipboardUtils>('getImagePNG')!
-export const invites = findByProps<DiscordModules.InviteUtils>('createInvite')!
-export const commands = findByProps('getBuiltInCommands')!
-export const toasts = findByFilePath<DiscordModules.ToastActionCreators, true>(
-    'modules/toast/native/ToastActionCreators.tsx',
-    true,
+        t: Record<
+            string,
+            (() => {
+                locale: string
+                /**
+                 * Keyless AST structure
+                 * @see Android's `base.apk/res/raw/intl_messages_*.jsona`
+                 * @see {@link https://github.com/discord/discord-intl/blob/main/packages/intl-ast/index.ts}
+                 */
+                ast: string | import('@discord/intl-ast').AstNode[]
+                reserialize(): string
+            }) & {
+                __phantom: unknown
+            }
+        >
+    }>('intl'),
 )!
-export const filePicker = findByProps<DiscordModules.FilePickerUtils>('handleDocumentSelection')!
-export const messages = findByProps<DiscordModules.MessageUtils>('sendBotMessage')!
+export const intlModule = find(byProps<typeof import('@discord/intl')>('runtimeHashMessageKey'))!
 
-export const NavigationStack = findByProps<typeof import('@react-navigation/stack')>('createStackNavigator')!
-export const NavigationNative = findByProps<typeof import('@react-navigation/native')>('NavigationContainer')!
+export const Logger = find(byName<typeof DiscordModules.Logger>('Logger'))!
+
+export const actionSheets = find(byProps<DiscordModules.ActionSheets>('hideActionSheet'))!
+export const alerts = find(byProps<DiscordModules.Alerts>('openAlert', 'dismissAlert'))!
+export const channels = find(byProps('getVoiceChannelId'))!
+export const links = find(byProps<DiscordModules.LinkingUtils>('openURL', 'openDeeplink'))!
+export const clipboard = find(byProps<DiscordModules.ClipboardUtils>('getImagePNG'))!
+export const invites = find(byProps<DiscordModules.InviteUtils>('createInvite'))!
+export const commands = find(byProps('getBuiltInCommands'))!
+export const toasts = find(
+    byFilePath<DiscordModules.ToastActionCreators>('modules/toast/native/ToastActionCreators.tsx'),
+)!
+export const filePicker = find(byProps<DiscordModules.FilePickerUtils>('handleDocumentSelection'))!
+export const messages = find(byProps<DiscordModules.MessageUtils>('sendBotMessage'))!
+
+export const NavigationStack = find(byProps<typeof import('@react-navigation/stack')>('createStackNavigator'))!
+export const NavigationNative = find(byProps<typeof import('@react-navigation/native')>('NavigationContainer'))!
 
 export interface NavigationNativeStackNavigationParamList {
     [Page: string]: any
@@ -64,34 +67,37 @@ export interface NavigationNativeStackNavigationParamList {
 
 export const { TextStyleSheet, createStyles, dismissAlerts, openAlert } = lazyDestructure(
     () =>
-        findByProps.eager<{
-            createStyles: DiscordModules.Styles.CreateStylesFn
-            TextStyleSheet: DiscordModules.Styles.TextStyleSheet
-            dismissAlerts: DiscordModules.Alerts['dismissAlerts']
-            openAlert: DiscordModules.Alerts['openAlert']
-        }>('createStyles', 'TextStyleSheet')!,
+        findEager(
+            byProps<{
+                createStyles: DiscordModules.Styles.CreateStylesFn
+                TextStyleSheet: DiscordModules.Styles.TextStyleSheet
+                dismissAlerts: DiscordModules.Alerts['dismissAlerts']
+                openAlert: DiscordModules.Alerts['openAlert']
+            }>('createStyles', 'TextStyleSheet'),
+        )!,
 )
 
-export const showSimpleActionSheet = findSingleProp<typeof DiscordModules.ActionSheets.showSimpleActionSheet>('showSimpleActionSheet')!
+export const showSimpleActionSheet =
+    findSingleProp<typeof DiscordModules.ActionSheets.showSimpleActionSheet>('showSimpleActionSheet')!
 
 /// FLUX
 
-export const Flux = findByProps('connectStores')
-export const FluxDispatcher = findByProps<DiscordModules.Flux.Dispatcher>('_interceptors')
+export const Flux = find(byProps('connectStores'))
+export const FluxDispatcher = find(byProps<DiscordModules.Flux.Dispatcher>('_interceptors'))
 
 /// REACT
 
-export const assetsRegistry = findByProps<typeof ReactNativeInternals.AssetsRegistry>('registerAsset')!
+export const assetsRegistry = find(byProps<typeof ReactNativeInternals.AssetsRegistry>('registerAsset'))!
 
 // Declarations are made in shims/deps.ts
 export { React, ReactNative }
-export const ReactJSXRuntime = findByProps<typeof import('react/jsx-runtime')>('jsx', 'jsxs')!
+export const ReactJSXRuntime = find(byProps<typeof import('react/jsx-runtime')>('jsx', 'jsxs'))!
 
 /// OTHERS
 
-export const semver = findByProps<typeof import('semver')>('SEMVER_SPEC_VERSION')!
-export const xxhash64 = findByProps<typeof import('@intrnl/xxhash64')>('XXH64')!
-export const nobleHashesUtils = findByProps<typeof import('@noble/hashes/utils')>('randomBytes')!
+export const semver = find(byProps<typeof import('semver')>('SEMVER_SPEC_VERSION'))!
+export const xxhash64 = find(byProps<typeof import('@intrnl/xxhash64')>('XXH64'))!
+export const nobleHashesUtils = find(byProps<typeof import('@noble/hashes/utils')>('randomBytes'))!
 export * from 'events'
 
 export const _ = lazyValue(() => require('lodash')) as typeof import('lodash')

--- a/libraries/modules/src/common/index.ts
+++ b/libraries/modules/src/common/index.ts
@@ -1,13 +1,13 @@
 import { lazyDestructure, lazyValue } from '@revenge-mod/utils/lazy'
 
+import { byName, byProps } from '../filters'
+import { find, findByFilePath, findEager, findSingleProp } from '../finders'
+
 import React from 'react'
 import ReactNative from 'react-native'
 
 import type { ReactNativeInternals } from '@revenge-mod/revenge'
 import type { DiscordModules } from '../types'
-
-import { byFilePath, byName, byProps } from '@revenge-mod/modules/filters'
-import { find, findEager, findSingleProp } from '../finders'
 
 export * as components from './components'
 export * as stores from './stores'
@@ -52,8 +52,8 @@ export const links = find(byProps<DiscordModules.LinkingUtils>('openURL', 'openD
 export const clipboard = find(byProps<DiscordModules.ClipboardUtils>('getImagePNG'))!
 export const invites = find(byProps<DiscordModules.InviteUtils>('createInvite'))!
 export const commands = find(byProps('getBuiltInCommands'))!
-export const toasts = find(
-    byFilePath<DiscordModules.ToastActionCreators>('modules/toast/native/ToastActionCreators.tsx'),
+export const toasts = findByFilePath<DiscordModules.ToastActionCreators>(
+    'modules/toast/native/ToastActionCreators.tsx',
 )!
 export const filePicker = find(byProps<DiscordModules.FilePickerUtils>('handleDocumentSelection'))!
 export const messages = find(byProps<DiscordModules.MessageUtils>('sendBotMessage'))!

--- a/libraries/modules/src/common/stores.ts
+++ b/libraries/modules/src/common/stores.ts
@@ -1,6 +1,7 @@
-import { findByStoreName } from '../finders'
+import { byStoreName } from '@revenge-mod/modules/filters'
+import { find } from '../finders'
 
-export const ThemeStore = findByStoreName<{
+export const ThemeStore = find(byStoreName<{
     getName(): 'ThemeStore'
     theme: string
-}>('ThemeStore')!
+}>('ThemeStore'))!

--- a/libraries/modules/src/common/stores.ts
+++ b/libraries/modules/src/common/stores.ts
@@ -1,7 +1,8 @@
 import { byStoreName } from '@revenge-mod/modules/filters'
 import { find } from '../finders'
 
-export const ThemeStore = find(byStoreName<{
-    getName(): 'ThemeStore'
-    theme: string
-}>('ThemeStore'))!
+export const ThemeStore = find(
+    byStoreName<{
+        theme: string
+    }>('ThemeStore'),
+)!

--- a/libraries/modules/src/constants.ts
+++ b/libraries/modules/src/constants.ts
@@ -4,19 +4,21 @@ import { createBitFlagEnum } from '@revenge-mod/utils/enums'
  * The module flags
  */
 export const MetroModuleFlags = createBitFlagEnum('Blacklisted', 'Asset')
+
 /**
- * The module lookup flags
+ * The lookup registry flags
  */
-export const MetroModuleLookupFlags = createBitFlagEnum('NotFound', 'FullLookup')
+export const MetroModuleLookupRegistryFlags = createBitFlagEnum('NotFound', 'FullLookup')
 
 /**
  * The module ID for the index module
  */
 export const IndexMetroModuleId = 0
+
 /**
  * The Metro cache version
  */
-export const MetroCacheVersion = 3
+export const MetroCacheVersion = 4
 
 /**
  * The storage key for the Metro cache

--- a/libraries/modules/src/constants.ts
+++ b/libraries/modules/src/constants.ts
@@ -11,11 +11,6 @@ export const MetroModuleFlags = createBitFlagEnum('Blacklisted', 'Asset')
 export const MetroModuleLookupRegistryFlags = createBitFlagEnum('NotFound', 'FullLookup')
 
 /**
- * The module ID for the index module
- */
-export const IndexMetroModuleId = 0
-
-/**
  * The Metro cache version
  */
 export const MetroCacheVersion = 4

--- a/libraries/modules/src/filters.ts
+++ b/libraries/modules/src/filters.ts
@@ -3,6 +3,7 @@ import { createFilter } from './utils/filters'
 export * from './utils/filters'
 
 import type { FilterFunction } from '@revenge-mod/modules'
+import type { AnyObject } from '@revenge-mod/shared/types'
 
 type Filter<F> = F extends (...args: infer A) => FilterFunction<any>
     ? F & {
@@ -10,11 +11,8 @@ type Filter<F> = F extends (...args: infer A) => FilterFunction<any>
       }
     : never
 
-type ByPropsArgs<T extends Record<string, any> = Record<string, any>> = [
-    prop: keyof T,
-    ...props: Array<keyof T | (string & {})>,
-]
-type ByProps = Filter<<T extends Record<string, any>>(...args: ByPropsArgs<T>) => FilterFunction<ByPropsArgs<T>, T>>
+type ByPropsArgs<T extends AnyObject = AnyObject> = [prop: keyof T, ...props: Array<keyof T | (string & {})>]
+type ByProps = Filter<<T extends AnyObject>(...args: ByPropsArgs<T>) => FilterFunction<ByPropsArgs<T>, T>>
 
 /**
  * Filters exports where specified properties are truthy
@@ -25,14 +23,14 @@ type ByProps = Filter<<T extends Record<string, any>>(...args: ByPropsArgs<T>) =
  * @param props Additional properties to search for
  */
 export const byProps = createFilter<ByPropsArgs>(
-    (props, m) => props.length === 1 ? m[props[0]] : props.every(p => m[p]),
+    (props, m) => (props.length === 1 ? m[props[0]] : props.every(p => m[p])),
     props => `revenge.props(${props.join(',')})`,
 ) as ByProps
 
-type ByNameArgs<T extends { name?: string }> = [name: NameOf<T>]
-type NameOf<T extends { name?: string }> = T['name'] extends undefined ? string : T['name']
+type ByNameArgs<T extends AnyObject> = [name: NameOf<T>]
+type NameOf<T extends AnyObject> = T['name'] extends string ? T['name'] : string
 type ByName = Filter<
-    <T extends { name?: string }>(...args: ByNameArgs<T>) => FilterFunction<ByNameArgs<T>, T & { name: NameOf<T> }>
+    <T extends AnyObject>(...args: ByNameArgs<T>) => FilterFunction<ByNameArgs<T>, T & { name: NameOf<T> }>
 >
 
 /**
@@ -47,10 +45,10 @@ export const byName = createFilter<Parameters<ByName>>(
     ([name]) => `revenge.name(${name})`,
 ) as ByName
 
-type ByDisplayNameArgs<T extends { displayName?: string }> = [displayName: DisplayNameOf<T>]
-type DisplayNameOf<T extends { displayName?: string }> = T['displayName'] extends undefined ? string : T['displayName']
+type ByDisplayNameArgs<T extends AnyObject> = [displayName: DisplayNameOf<T>]
+type DisplayNameOf<T extends AnyObject> = T['displayName'] extends string ? T['displayName'] : string
 type ByDisplayName = Filter<
-    <T extends { displayName?: string }>(
+    <T extends AnyObject>(
         ...args: ByDisplayNameArgs<T>
     ) => FilterFunction<ByDisplayNameArgs<T>, T & { displayName: DisplayNameOf<T> }>
 >
@@ -67,12 +65,10 @@ export const byDisplayName = createFilter<Parameters<ByDisplayName>>(
     ([displayName]) => `revenge.displayName(${displayName})`,
 ) as ByDisplayName
 
-type ByTypeNameArgs<T extends { type?: { name?: string } }> = [typeName: TypeNameOf<T>]
-type TypeNameOf<T extends { type?: { name?: string } }> = T['type'] extends { name?: string }
-    ? T['type']['name']
-    : string
+type ByTypeNameArgs<T extends AnyObject> = [typeName: TypeNameOf<T>]
+type TypeNameOf<T extends AnyObject> = T['type']['name'] extends string ? T['type']['name'] : string
 type ByTypeName = Filter<
-    <T extends { type?: { name?: string } }>(
+    <T extends AnyObject>(
         ...args: ByTypeNameArgs<T>
     ) => FilterFunction<ByTypeNameArgs<T>, T & { type: { name: TypeNameOf<T> } }>
 >
@@ -89,10 +85,10 @@ export const byTypeName = createFilter<Parameters<ByTypeName>>(
     ([typeName]) => `revenge.typeName(${typeName})`,
 ) as ByTypeName
 
-type ByStoreNameArgs<T extends { getName?: () => string }> = [storeName: StoreNameOf<T>]
-type StoreNameOf<T extends { getName?: () => string }> = T['getName'] extends () => infer U ? U : string
+type ByStoreNameArgs<T extends AnyObject> = [storeName: StoreNameOf<T>]
+type StoreNameOf<T extends AnyObject> = T['getName'] extends () => infer U ? U : string
 type ByStoreName = Filter<
-    <T extends { getName?: () => string }>(
+    <T extends AnyObject>(
         ...args: ByStoreNameArgs<T>
     ) => FilterFunction<ByStoreNameArgs<T>, T & { getName: () => StoreNameOf<T> }>
 >
@@ -100,7 +96,7 @@ type ByStoreName = Filter<
 /**
  * Filters for exports with matching store names.
  *
- * `m.getName?.length === 0 && m.getName() === name`
+ * `m.getName.length === 0 && m.getName() === name`
  *
  * @param name The store name to search for
  */

--- a/libraries/modules/src/filters.ts
+++ b/libraries/modules/src/filters.ts
@@ -30,19 +30,6 @@ export const byProps = createFilter<ByPropsArgs>(
     props => `revenge.props(${props.join(',')})`,
 ) as ByProps
 
-type ByMutablePropsArgs<T extends Record<string, any> = Record<string, any>> = [prop: keyof T]
-type ByMutableProp = Filter<
-    <T extends Record<string, any>>(...args: ByMutablePropsArgs<T>) => FilterFunction<ByMutablePropsArgs<T>, T>
->
-
-/**
- * Filters for exports which has the given mutable property
- */
-export const byMutableProp = createFilter<ByMutablePropsArgs>(
-    ([prop], m) => m?.[prop] && !Object.getOwnPropertyDescriptor(m, prop)?.get,
-    ([prop]) => `revenge.mutableProp(${prop})`,
-) as ByMutableProp
-
 type ByNameArgs<T extends { name?: string }> = [name: NameOf<T>]
 type NameOf<T extends { name?: string }> = T['name'] extends undefined ? string : T['name']
 type ByName = Filter<

--- a/libraries/modules/src/filters.ts
+++ b/libraries/modules/src/filters.ts
@@ -1,4 +1,3 @@
-import { cache } from './metro/caches'
 import { createFilter } from './utils/filters'
 
 export * from './utils/filters'
@@ -109,20 +108,6 @@ export const byStoreName = createFilter<Parameters<ByStoreName>>(
     ([name], m) => m.getName?.length === 0 && m.getName() === name,
     ([name]) => `revenge.storeName(${name})`,
 ) as ByStoreName
-
-type ByFilePath = Filter<<T>(path: string) => FilterFunction<[path: string], T>>
-
-/**
- * Filters for exports with matching imported file path. Useful for finding modules whose properties are not unique.
- *
- * @param path The file path to search for
- */
-export const byFilePath = createFilter<Parameters<ByFilePath>>(
-    ([path], _, id) => {
-        return cache.moduleFilePaths.get(id) === path
-    },
-    ([path]) => `revenge.filePath(${path})`,
-) as ByFilePath
 
 type BySinglePropArgs<T extends Record<string, any>> = [prop: keyof T]
 type BySingleProp = Filter<

--- a/libraries/modules/src/finders.ts
+++ b/libraries/modules/src/finders.ts
@@ -191,10 +191,26 @@ export function* findAllEager<F extends FilterFunction<any>>(
     for (const [, exports] of findAllModules(filter)) yield exports
 }
 
-export function findProp<T>(prop: string, ...props: string[]) {
-    return lazyValue(() => findEager(byProps(prop, ...props))?.[prop] as T)
+/**
+ * Finds a property and accesses it lazily, where all specified properties are truthy
+ * @param props An array of properties to search for. The first element in the array is the property that will be accessed.
+ * @param options The options for the finder
+ * @param options.extraProps Additional properties to use for filtering
+ * @returns A lazy value of the property with the given property name in exports, where all specified properties are truthy
+ */
+export function findProp<T>(prop: string, options?: LazyFinderOptions & { extraProps?: string[] }) {
+    return lazyValue(
+        () => findEager(byProps(prop, ...(options?.extraProps ?? [])), options)?.[prop] as T,
+        options?.lazyOptions,
+    )
 }
 
-export function findSingleProp<T>(prop: string) {
-    return lazyValue(() => findEager(bySingleProp(prop))?.[prop] as T)
+/**
+ * Finds a property and accesses it lazily, where the specified property is truthy, and the export only has one property
+ * @param prop The property to search for
+ * @param options The options for the finder
+ * @returns A lazy value of the property with the given property name in exports, where the specified property is truthy, and the export only has one property
+ */
+export function findSingleProp<T>(prop: string, options?: LazyFinderOptions) {
+    return lazyValue(() => findEager(bySingleProp(prop), options)?.[prop] as T, options?.lazyOptions)
 }

--- a/libraries/modules/src/finders.ts
+++ b/libraries/modules/src/finders.ts
@@ -1,25 +1,26 @@
-import { lazyValue } from '@revenge-mod/utils/lazy'
-import { byDisplayName, byFilePath, byName, byProps, byQuery, bySingleProp, byStoreName, byTypeName } from './filters'
-import { modulesForFinder, requireModule } from './metro'
+import { isModuleExportsBad, moduleIdsForFilter, requireModule } from './metro'
 import { cacherFor } from './metro/caches'
-import { createLazyModule, lazyContextSymbol } from './utils/lazy'
+import { createLazyModule, createLazyModuleById, lazyContextSymbol } from './utils/lazy'
 
-import type { If, Nullable as Undefinable } from '@revenge-mod/shared/types'
-import type { FilterFn, LazyModule, Metro } from './types'
+import { lazyValue, type LazyOptions } from '@revenge-mod/utils/lazy'
+import type { FilterFunction, InferFilterFunctionReturnType, LazyModule, Metro } from './types'
+import { byProps, bySingleProp } from '@revenge-mod/modules/filters'
 
-function filterExports<A extends unknown[]>(moduleExports: Metro.ModuleExports, moduleId: number, filter: FilterFn<A>) {
-    if (moduleExports.default && moduleExports.__esModule && filter(moduleExports.default, moduleId, true)) {
-        return {
-            exports: filter.raw ? moduleExports : moduleExports.default,
-            isDefaultExport: !filter.raw,
-        }
+function filterExports<F extends FilterFunction<any>>(
+    moduleExports: Metro.ModuleExports,
+    moduleId: number,
+    filter: F,
+    opts?: FinderOptions,
+): [] | [exports: Metro.ModuleExports, pass: boolean] {
+    if (!opts?.skipDefaultExportCheck && moduleExports.__esModule) {
+        const defaultExport = moduleExports.default
+        if ((defaultExport || typeof defaultExport === 'number') && filter(defaultExport, moduleId))
+            return [opts?.returnWholeModule ? moduleExports : defaultExport, true]
     }
 
-    if (!filter.raw && filter(moduleExports, moduleId, false)) {
-        return { exports: moduleExports, isDefaultExport: false }
-    }
+    if (filter(moduleExports, moduleId)) return [moduleExports, true]
 
-    return {}
+    return []
 }
 
 /**
@@ -27,545 +28,173 @@ function filterExports<A extends unknown[]>(moduleExports: Metro.ModuleExports, 
  * @param filter The filter to match
  * @returns An object containing the module ID and exports of the first module which the given filter matches
  */
-export const findId = Object.assign(
-    function findModuleId<A extends unknown[]>(filter: FilterFn<A>) {
-        const { cache, finish } = cacherFor(filter.key)
+export function findModule<F extends FilterFunction<any>>(
+    filter: F,
+    opts?: FinderOptions,
+): [Metro.ModuleID, Metro.ModuleExports] | [] {
+    const { cache, finish } = cacherFor(filter.key, !!opts?.returnWholeModule)
 
-        for (const [id, moduleExports] of modulesForFinder(filter.key)) {
-            const { exports, isDefaultExport } = filterExports(moduleExports, id, filter)
-            if (typeof exports !== 'undefined') {
-                cache(id, exports)
-                finish(false)
-                return [id, isDefaultExport]
-            }
+    for (const id of moduleIdsForFilter(filter.key, false)) {
+        const fullExports = requireModule(id)
+        if (isModuleExportsBad(fullExports)) continue
+
+        const [exports, pass] = filterExports(fullExports, id, filter, opts)
+        if (pass) {
+            const cached = cache(id, exports)
+            if (!cached) continue
+
+            finish(false)
+            return [id, exports]
         }
+    }
 
-        finish(true)
-        return []
-    },
-    {
-        /**
-         * Yields all modules where filter returns a truthy value.
-         * @param filter The filter to match
-         * @returns A generator that yields an array containing the module ID and whether the export is the default export
-         */
-        all: function* findModuleIdAll<A extends unknown[]>(filter: FilterFn<A>) {
-            const { cache, finish } = cacherFor(filter.key)
-
-            let found = false
-
-            for (const [id, moduleExports] of modulesForFinder(filter.key, true)) {
-                const { exports, isDefaultExport } = filterExports(moduleExports, id, filter)
-                if (typeof exports !== 'undefined') {
-                    cache(id, exports)
-                    found = true
-                    yield [id, isDefaultExport]
-                }
-            }
-
-            finish(found, true)
-        },
-    },
-)
+    finish(true)
+    return []
+}
 
 /**
- * Finds an export where the given filter returns a truthy value
+ * Yields all modules where filter returns a truthy value.
  * @param filter The filter to match
- * @returns The exports of the first module which the given filter matches
+ * @returns A generator that yields an array containing the module ID and whether the export is the default export
  */
-export const find = Object.assign(
-    function findModule<A extends unknown[]>(filter: FilterFn<A>) {
-        return createLazyModule(filter)
-    },
-    {
-        /**
-         * Returns all exports where filter returns a truthy value.
-         * @param filter The filter to match
-         * @returns An array of exports
-         */
-        all: function* findModuleAll<A extends unknown[]>(filter: FilterFn<A>) {
-            for (const [id, isDefaultExport] of findId.all(filter)) {
-                if (typeof id === 'number') yield isDefaultExport ? requireModule(id).default : requireModule(id)
-            }
-        },
-        eager: function findModuleEager<A extends unknown[]>(filter: FilterFn<A>) {
-            const [id, defaultExport] = findId(filter)
-            // id can be 0
-            if (typeof id === 'number') return defaultExport ? requireModule(id).default : requireModule(id)
-        },
-    },
-)
+export function* findAllModules<F extends FilterFunction<any>>(
+    filter: F,
+    opts?: FinderOptions,
+): Generator<[Metro.ModuleID, InferFilterFunctionReturnType<F>], void, unknown> {
+    const { cache, finish } = cacherFor(filter.key, !!opts?.returnWholeModule)
 
-export type NonExact<T = unknown> = Branded<T, 'NonExact'>
+    let found = false
 
-export type ByProps<
-    Struct = Record<string, Metro.ModuleExports[string]>,
-    AdditionalProps extends string = string,
-> = Undefinable<
-    Struct extends NonExact
-        ? Struct & {
-              [Key in AdditionalProps]: Metro.ModuleExports[Key]
-          } & {
-              [Key in PropertyKey]: Metro.ModuleExports[Key]
-          }
-        : Struct
+    for (const id of moduleIdsForFilter(filter.key, true)) {
+        const fullExports = requireModule(id)
+        if (isModuleExportsBad(fullExports)) continue
+
+        const [exports, pass] = filterExports(fullExports, id, filter, opts)
+        if (pass) {
+            const cached = cache(id, exports)
+            if (!cached) continue
+            found = true
+            yield [id, exports]
+        }
+    }
+
+    finish(found, true)
+}
+
+export type FinderOptions = {
+    /**
+     * Whether to return the whole module instead of just the default export
+     * @default false
+     */
+    returnWholeModule?: boolean
+    /**
+     * Whether the finder should skip filtering the default export. The default export check is always prioritized over the whole module check.
+     * @default false
+     */
+    skipDefaultExportCheck?: boolean
+}
+
+export type LazyFinderOptions<L extends LazyOptions = LazyOptions> = FinderOptions & {
+    /**
+     * The options for lazy modules
+     */
+    lazyOptions?: L
+}
+
+export type AsyncFinderOptions = LazyFinderOptions & {
+    /**
+     * The timeout in milliseconds before the promise resolves with undefined if nothing is found
+     * @default 3000
+     */
+    timeout?: number
+}
+
+export type LazyFinderReturn<F extends FilterFunction<any>, LF extends LazyFinderOptions> = LazyModule<
+    FinderReturn<F, LF>
 >
+// TODO: Type this properly
+//    & NonNullable<NonNullable<LF['lazyOptions']>['exemptedEntries']>
+
+export type FinderReturn<F extends FilterFunction<any>, FO extends FinderOptions> =
+    | (FO['returnWholeModule'] extends true
+          ? { default: InferFilterFunctionReturnType<F> }
+          : InferFilterFunctionReturnType<F>)
+    | undefined
 
 /**
- * Finds an export with specified properties
- *
- * - Filter: `m[prop] && props.every(p => m[p])`
- * - Returns: `m`
- *
- * @param prop The property to search for
- * @param props Additional properties to search for
- * @returns The module exports
+ * Lazily finds an export where the given filter returns a truthy value
+ * @param filter The filter to match
+ * @param opts The options for the finder
+ * @returns Lazy exports of the first module which the given filter matches
  */
-export const findByProps = Object.assign(
-    function findByPropsLazy<T = Record<string, Metro.ModuleExports[string]>, P extends string = string>(
-        prop: keyof T,
-        ...props: P[]
-    ) {
-        return find(byProps(prop as string, ...(props as string[]))) as LazyModule<ByProps<T, P>>
-    },
-    {
-        async: function findByPropsAsync<T = Record<string, Metro.ModuleExports[string]>, P extends string = string>(
-            prop: keyof T,
-            ...propsAndOrTimeout: [...P[], number] | P[]
-        ) {
-            const cloned = [...propsAndOrTimeout]
-            const timeout = typeof cloned[cloned.length - 1] === 'number' ? (cloned.pop() as number) : 1000
-            return new Promise<ByProps<T, P>>(resolve => {
-                const id = setTimeout(() => resolve(undefined), timeout)
-                findByProps(prop, ...(cloned as string[]))![lazyContextSymbol].getExports(
-                    (exp: Metro.ModuleExports) => {
-                        clearTimeout(id)
-                        resolve(exp)
-                    },
-                )
-            })
-        },
-        eager: function findByPropsEager<T = Record<string, Metro.ModuleExports[string]>, P extends string = string>(
-            prop: keyof T,
-            ...props: P[]
-        ) {
-            return find.eager(byProps(prop as string, ...(props as string[]))) as ByProps<T, P>
-        },
-        /**
-         * Yield all exports with specified properties
-         *
-         * - Filter: `m[prop] && props.every(p => m[p])`
-         * - Returns: `m`
-         *
-         * @param prop The property to search for
-         * @param props Additional properties to search for
-         * @returns The module exports
-         */
-        all: function findByPropsAll<T = Record<string, Metro.ModuleExports[string]>, K extends string = string>(
-            prop: keyof T,
-            ...props: K[]
-        ) {
-            type IteratorValue = Undefinable<
-                T & {
-                    [Key in K]: Metro.ModuleExports[Key]
-                }
-            >
-            return find.all(byProps(prop as string, ...(props as string[]))) as Iterator<
-                IteratorValue,
-                IteratorValue,
-                IteratorValue
-            >
-        },
-    },
-)
-
-export type ByName<Value extends { name: string }, DefaultExport extends boolean> = Undefinable<
-    If<DefaultExport, ByNameDefaultExport<Value>, { default: ByNameDefaultExport<Value> }>
->
-
-type ByNameDefaultExport<V extends { name: string }> = NonNullable<ByProps<V>>
+export function find<F extends FilterFunction<any>, LF extends LazyFinderOptions>(
+    filter: F,
+    opts?: LF,
+): LazyFinderReturn<F, LF> {
+    return createLazyModule(filter, opts)
+}
 
 /**
- * Returns an export with matching name
- *
- * - Filter: `m.name === name`
- * - Yields: `m`, or `{ default: m }` if `returnDefaultExport` is `false`
- *
- * @param name The name to search for
- * @param returnDefaultExport Whether to return the default export instead of the whole module
- * @returns The module exports
+ * Asynchronously finds an export where the given filter returns a truthy value
+ * @param filter The filter to match
+ * @param opts The options for the finder
+ * @returns A promise that resolves with the exports of the first module which the given filter matches
  */
-export const findByName = Object.assign(
-    function findByNameLazy<V extends { name: string }, D extends boolean>(
-        name: V['name'],
-        returnDefaultExport: D = true as D,
-    ) {
-        return find(returnDefaultExport ? byName(name) : byName.raw(name)) as LazyModule<ByName<V, D>>
-    },
-    {
-        async: function findByNameAsync<V extends { name: string }, D extends boolean>(
-            name: V['name'],
-            returnDefaultExport: D = true as D,
-            timeout = 1000,
-        ) {
-            return new Promise<ByName<V, D>>(resolve => {
-                const id = setTimeout(() => resolve(undefined), timeout)
-                findByName(name, returnDefaultExport)![lazyContextSymbol].getExports((exp: Metro.ModuleExports) => {
-                    clearTimeout(id)
-                    resolve(exp)
-                })
-            })
-        },
-        eager: function findByNameEager<V extends { name: string }, D extends boolean>(
-            name: V['name'],
-            returnDefaultExport: D = true as D,
-        ) {
-            return find.eager(returnDefaultExport ? byName(name) : byName.raw(name)) as ByName<V, D>
-        },
-        /**
-         * Yields all exports with matching name
-         *
-         * - Filter: `m.name === name`
-         * - Yields: `m`, or `{ default: m }` if `returnDefaultExport` is `false`
-         *
-         * @param name The name to search for
-         * @param returnDefaultExport Whether to return the default export instead of the whole module
-         * @returns The module exports
-         */
-        all: function findByNameAll<V extends { name: string }, D extends boolean>(
-            name: V['name'],
-            returnDefaultExport: D = true as D,
-        ) {
-            type IteratorValue = ByName<V, D>
-
-            return find.all(returnDefaultExport ? byName(name) : byName.raw(name)) as Iterator<
-                IteratorValue,
-                IteratorValue,
-                IteratorValue
-            >
-        },
-    },
-)
-
-export type ByDisplayName<Value extends { displayName: string }, DefaultExport extends boolean> = Undefinable<
-    If<DefaultExport, ByDisplayNameDefaultExport<Value>, { default: ByDisplayNameDefaultExport<Value> }>
->
-
-type ByDisplayNameDefaultExport<V extends { displayName: string }> = NonNullable<ByProps<V>>
+export function findAsync<F extends FilterFunction<any>, AF extends AsyncFinderOptions>(
+    filter: F,
+    opts?: AF,
+): Promise<FinderReturn<F, AF>> {
+    return new Promise(resolve => {
+        const id = setTimeout(() => resolve(undefined), opts?.timeout ?? 3000)
+        find(filter, opts)![lazyContextSymbol].exports((exp: Metro.ModuleExports) => {
+            clearTimeout(id)
+            resolve(exp)
+        })
+    })
+}
 
 /**
- * Finds an export by its display name
- *
- * - Filter: `m.displayName === name`
- * - Returns: `m`, or `{ default: m }` if `returnDefaultExport` is `false`
- *
- * @param name The display name to search for
- * @param returnDefaultExport Whether to return the default export instead of the whole module
- * @returns The module exports
+ * Eagerly finds an export where the given filter returns a truthy value
+ * @param filter
+ * @param opts The options for the finder
+ * @returns Exports of the first module which the given filter matches
  */
-export const findByDisplayName = Object.assign(
-    function findByDisplayNameLazy<V extends { displayName: string }, D extends boolean>(
-        name: V['displayName'],
-        returnDefaultExport: D = true as D,
-    ) {
-        return find(returnDefaultExport ? byDisplayName(name) : byDisplayName.raw(name)) as LazyModule<
-            ByDisplayName<V, D>
-        >
-    },
-    {
-        async: function findByDisplayNameAsync<V extends { displayName: string }, D extends boolean>(
-            name: V['displayName'],
-            returnDefaultExport: D = true as D,
-            timeout = 1000,
-        ) {
-            return new Promise<ByDisplayName<V, D>>(resolve => {
-                const id = setTimeout(() => resolve(undefined), timeout)
-                findByDisplayName(name, returnDefaultExport)![lazyContextSymbol].getExports(
-                    (exp: Metro.ModuleExports) => {
-                        clearTimeout(id)
-                        resolve(exp)
-                    },
-                )
-            })
-        },
-        eager: function findByDisplayNameEager<V extends { displayName: string }, D extends boolean>(
-            name: V['displayName'],
-            returnDefaultExport: D = true as D,
-        ) {
-            return find.eager(returnDefaultExport ? byDisplayName(name) : byDisplayName.raw(name)) as ByDisplayName<
-                V,
-                D
-            >
-        },
-        /**
-         * Yields all exports with matching display name
-         *
-         * - Filter: `m.displayName === name`
-         * - Yields: `m`, or `{ default: m }` if `returnDefaultExport` is `false`
-         *
-         * @param name The display name to search for
-         * @param returnDefaultExport Whether to return the default export instead of the whole module
-         * @returns The module exports
-         */
-        all: function findByDisplayNameAll<V extends { displayName: string }, D extends boolean>(
-            name: V['displayName'],
-            returnDefaultExport: D = true as D,
-        ) {
-            type IteratorValue = ByDisplayName<V, D>
-
-            return find.all(returnDefaultExport ? byDisplayName(name) : byDisplayName.raw(name)) as Iterator<
-                IteratorValue,
-                IteratorValue,
-                IteratorValue
-            >
-        },
-    },
-)
-
-export type ByTypeName<Value extends { type: { name: string } }, DefaultExport extends boolean> = Undefinable<
-    If<DefaultExport, ByTypeNameDefaultExport<Value>, { default: ByTypeNameDefaultExport<Value> }>
->
-
-type ByTypeNameDefaultExport<V extends { type: { name: string } }> = NonNullable<ByProps<V>>
+export function findEager<F extends FilterFunction<any>, FF extends FinderOptions>(
+    filter: F,
+    opts?: FF,
+): FinderReturn<F, FF> {
+    const [, exports] = findModule(filter, opts)
+    return exports
+}
 
 /**
- * Finds an export by its type name (`x.type.name`)
- *
- * - Filter: `m.type.name === name`
- * - Returns: `m`, or `{ default: m }` if `returnDefaultExport` is `false`
- *
- * @param name The type name to search for
- * @param returnDefaultExport Whether to return the default export instead of the whole module
- * @returns The module exports
+ * Lazily yields all exports where filter returns a truthy value.
+ * @param filter The filter to match
+ * @param opts The options for the finder
+ * @yields Lazy exports of all modules which the given filter matches
  */
-export const findByTypeName = Object.assign(
-    function findByTypeNameLazy<V extends { type: { name: string } }, D extends boolean>(
-        name: V['type']['name'],
-        returnDefaultExport: D = true as D,
-    ) {
-        return find(returnDefaultExport ? byTypeName(name) : byTypeName.raw(name)) as LazyModule<ByTypeName<V, D>>
-    },
-    {
-        async: function findByTypeNameAsync<V extends { type: { name: string } }, D extends boolean>(
-            name: V['type']['name'],
-            returnDefaultExport: D = true as D,
-            timeout = 1000,
-        ) {
-            return new Promise<ByTypeName<V, D>>(resolve => {
-                const id = setTimeout(() => resolve(undefined), timeout)
-                findByTypeName(name, returnDefaultExport)![lazyContextSymbol].getExports((exp: Metro.ModuleExports) => {
-                    clearTimeout(id)
-                    resolve(exp)
-                })
-            })
-        },
-        eager: function findByTypeNameEager<V extends { type: { name: string } }, D extends boolean>(
-            name: V['type']['name'],
-            returnDefaultExport: D = true as D,
-        ) {
-            return find.eager(returnDefaultExport ? byTypeName(name) : byTypeName.raw(name)) as ByTypeName<V, D>
-        },
-        /**
-         * Yields all exports by its type name (`x.type.name`)
-         *
-         * - Filter: `m.type.name === name`
-         * - Returns: `m`, or `{ default: m }` if `returnDefaultExport` is `false`
-         *
-         * @param name The type name to search for
-         * @param returnDefaultExport Whether to return the default export instead of the whole module
-         * @returns The module exports
-         */
-        all: function findByTypeNameAll<V extends { type: { name: string } }, D extends boolean>(
-            name: V['type']['name'],
-            returnDefaultExport: D = true as D,
-        ) {
-            type IteratorValue = ByTypeName<V, D>
-
-            return find.all(returnDefaultExport ? byTypeName(name) : byTypeName.raw(name)) as Iterator<
-                IteratorValue,
-                IteratorValue,
-                IteratorValue
-            >
-        },
-    },
-)
-
-export type ByStoreName<Value extends { getName(): string }> = ByProps<Value>
+export function* findAll<F extends FilterFunction<any>, LF extends LazyFinderOptions>(
+    filter: F,
+    opts?: LF,
+): Generator<LazyFinderReturn<F, LF>, void, unknown> {
+    for (const [id] of findAllModules(filter, opts)) yield createLazyModuleById(id, opts)
+}
 
 /**
- * Finds an export by its store name
- *
- * - Filter: `m.getName?.length === 0 && m.getName() === name`
- * - Returns: `m`
- *
- * @param name The store name to search for
- * @returns The module exports
+ * Eagerly yields all exports where filter returns a truthy value.
+ * @param filter The filter to match
+ * @yields Exports of all modules which the given filter matches
  */
-export const findByStoreName = Object.assign(
-    function findByStoreNameLazy<V extends { getName(): string }>(name: ReturnType<V['getName']>) {
-        return find(byStoreName(name)) as LazyModule<ByStoreName<V>>
-    },
-    {
-        async: function findByStoreNameAsync<V extends { getName(): string }>(
-            name: ReturnType<V['getName']>,
-            timeout = 5000,
-        ) {
-            return new Promise<ByStoreName<V>>(resolve => {
-                const id = setTimeout(() => resolve(undefined), timeout)
-                findByStoreName(name)![lazyContextSymbol].getExports((exp: Metro.ModuleExports) => {
-                    clearTimeout(id)
-                    resolve(exp)
-                })
-            })
-        },
-        eager: function findByStoreNameEager<V extends { getName(): string }>(name: ReturnType<V['getName']>) {
-            return find.eager(byStoreName(name)) as ByStoreName<V>
-        },
-    },
-)
+export function* findAllEager<F extends FilterFunction<any>>(
+    filter: F,
+): Generator<InferFilterFunctionReturnType<F>, void, unknown> {
+    for (const [, exports] of findAllModules(filter)) yield exports
+}
 
-export type ByFilePath<T extends Metro.ModuleExports, DefaultExport extends boolean> = ByProps<
-    If<DefaultExport, T, { default: T }>
->
+export function findProp<T>(prop: string, ...props: string[]) {
+    return lazyValue(() => findEager(byProps(prop, ...props))?.[prop] as T)
+}
 
-/**
- * Finds an export by its imported file path. Useful for finding modules whose properties are not very unique.
- *
- * - Returns: `m`, or `{ default: m }` if `returnDefaultExport` is `false`
- *
- * @param path The file path to search for
- * @param returnDefaultExport Whether to return the default export instead of the whole module **(default is `true`)**
- * @returns The module exports
- */
-export const findByFilePath = Object.assign(
-    function findByFilePathLazy<T extends Metro.ModuleExports, D extends boolean>(
-        path: string,
-        returnDefaultExport: D = false as D,
-    ) {
-        return find(byFilePath(path, returnDefaultExport)) as LazyModule<ByFilePath<T, D>>
-    },
-    {
-        async: function findByFilePathAsync<T extends Metro.ModuleExports, D extends boolean>(
-            path: string,
-            returnDefaultExport: D = true as D,
-            timeout = 1000,
-        ) {
-            return new Promise<ByFilePath<T, D>>(resolve => {
-                const id = setTimeout(() => resolve(undefined), timeout)
-                findByFilePath(path, returnDefaultExport)![lazyContextSymbol].getExports((exp: Metro.ModuleExports) => {
-                    clearTimeout(id)
-                    resolve(exp)
-                })
-            })
-        },
-        eager: function findByFilePathEager<T extends Metro.ModuleExports, D extends boolean>(
-            path: string,
-            returnDefaultExport = true,
-        ) {
-            return find.eager(byFilePath(path, returnDefaultExport)) as ByFilePath<T, D>
-        },
-    },
-)
-
-/**
- * Finds an export by its properties, and accesses it directly.
- * **This is not reliable for non-object-like values (eg. strings, numbers, booleans) since we cannot create proxies for those types
- * , only `findProp.async` and `findProp.eager` are reliable for such things.**
- *
- * - Filter: `m[prop] && props.every(p => m[p])`
- * - Returns: `m[prop]`
- *
- * @param prop The property to search for and access
- * @param filterProps Additional properties to search for
- * @returns The value of the module's exports' property
- */
-export const findProp = Object.assign(
-    function findPropLazy<T extends Metro.ModuleExports>(prop: string, ...filterProps: string[]) {
-        return lazyValue(() => findByProps.eager(prop, ...filterProps)?.[prop]) as LazyModule<Undefinable<T>>
-    },
-    {
-        async: function findPropAsync<T extends Metro.ModuleExports>(
-            prop: string,
-            ...filterPropsAndOrTimeout: [...string[], number] | string[]
-        ) {
-            return findByProps.async(prop, ...filterPropsAndOrTimeout).then(exports => exports?.[prop]) as Promise<
-                Undefinable<T>
-            >
-        },
-        eager: function findPropEager<T extends Metro.ModuleExports>(prop: string, ...filterProps: string[]) {
-            return findByProps.eager(prop, ...filterProps)?.[prop] as Undefinable<T>
-        },
-    },
-)
-
-export type BySingleProp<Value, Key extends string> = Undefinable<{ [K in Key]: Value }>
-
-/**
- * Finds an export by its single property
- *
- * - Filter: `m[prop] && Object.keys(m).length === 1`
- * - Returns: `m`
- *
- * @param name The property to search for
- * @param returnDefaultExport Whether to return the default export instead of the whole module
- * @returns The module exports
- */
-export const findBySingleProp = Object.assign(
-    function findBySinglePropLazy<T, K extends string>(name: K) {
-        return find(bySingleProp(name)) as LazyModule<BySingleProp<T, K>>
-    },
-    {
-        async: function findBySinglePropAsync<T, K extends string>(name: K, timeout = 1000) {
-            return new Promise<BySingleProp<T, K>>(resolve => {
-                const id = setTimeout(() => resolve(undefined), timeout)
-                findBySingleProp(name)![lazyContextSymbol].getExports((exp: Metro.ModuleExports) => {
-                    clearTimeout(id)
-                    resolve(exp)
-                })
-            })
-        },
-        eager: function findBySinglePropEager<T, K extends string>(name: K) {
-            return find.eager(bySingleProp(name as string)) as BySingleProp<T, K>
-        },
-    },
-)
-
-export const findSingleProp = Object.assign(
-    function findSinglePropLazy<T>(name: string) {
-        return lazyValue(() => findBySingleProp.eager(name)?.[name]) as LazyModule<Undefinable<T>>
-    },
-    {
-        async: function findSinglePropAsync<T>(name: string, timeout = 1000) {
-            return findBySingleProp.async(name, timeout).then(exports => exports?.[name]) as Promise<Undefinable<T>>
-        },
-        eager: function findSinglePropEager<T>(name: string) {
-            return findBySingleProp.eager(name)?.[name] as Undefinable<T>
-        },
-    },
-)
-
-/**
- * Finds an export by a query string **(very expensive, only use for debugging)**
- * @param query The query string to search for
- * @param caseSensitive Whether the search should be case-sensitive
- * @returns The module exports
- */
-export const findByQuery = Object.assign(
-    function findByQueryLazy() {
-        throw new Error('Lazy finding for byQuery(...) is not supported, use findByQuery.eager(...) instead')
-    },
-    {
-        eager: function findByQueryEager(query: string, caseSensitive = false) {
-            return find(byQuery(query, caseSensitive))
-        },
-        /**
-         * Yields all exports that match a query string **(very expensive, only use for debugging)**
-         * @param query The query string to search for
-         * @param caseSensitive Whether the search should be case-sensitive
-         * @returns All module exports
-         */
-        all: function findByQueryAll(query: string, caseSensitive = false) {
-            return find.all(byQuery(query, caseSensitive))
-        },
-    },
-)
+export function findSingleProp<T>(prop: string) {
+    return lazyValue(() => findEager(bySingleProp(prop))?.[prop] as T)
+}

--- a/libraries/modules/src/finders.ts
+++ b/libraries/modules/src/finders.ts
@@ -200,17 +200,19 @@ export function* findAllEager<F extends FilterFunction<any>>(
 }
 
 /**
- * Finds exports by its module file path
+ * Lazily finds exports by its module file path
  * @param path The module file path
  * @param options The options for the finder
  * @returns Exports of the module with the given file path
  */
-export function findByFilePath<T>(path: string, options?: FinderOptions) {
-    const id = cache.moduleFilePaths.get(path)
-    if (id === undefined) return
-    const exports = requireModule(id)
-    if (exports === undefined) return
-    return (!options?.wildcard && exports.__esModule ? exports.default : exports) as T
+export function findByFilePath<T>(path: string, options?: LazyFinderOptions) {
+    return lazyValue(() => {
+        const id = cache.moduleFilePaths.get(path)
+        if (id === undefined) return
+        const exports = requireModule(id)
+        if (exports === undefined) return
+        return (!options?.wildcard && exports.__esModule ? exports.default : exports) as T
+    }, options?.lazyOptions)
 }
 
 /**

--- a/libraries/modules/src/index.ts
+++ b/libraries/modules/src/index.ts
@@ -10,7 +10,6 @@ export async function createModulesLibrary() {
     const native = await import('./native')
 
     return {
-        constants,
         common,
         filters,
         native,

--- a/libraries/modules/src/metro/caches.ts
+++ b/libraries/modules/src/metro/caches.ts
@@ -100,25 +100,11 @@ export function requireAssetModules() {
             'Unable to create asset cache, cannot find assets-registry module ID, some assets may not load',
         )
 
-    let assetsRegistryExporterModuleId = 0
-    for (const [id, module] of modules) {
-        if (!module.dependencyMap) continue
-        if (module.dependencyMap.length === 1 && module.dependencyMap[0] === assetsRegistryModuleId) {
-            assetsRegistryExporterModuleId = id
-            break
-        }
-    }
-
-    if (!assetsRegistryExporterModuleId)
-        return void logger.warn(
-            'Unable to create asset cache, cannot find assets-registry exporter module ID, some assets may not load',
-        )
-
     logger.log('Importing all assets modules...')
 
     for (const [id, module] of modules) {
         if (!module.dependencyMap) continue
-        if (module.dependencyMap.length === 1 && module.dependencyMap[0] === assetsRegistryExporterModuleId)
+        if (module.dependencyMap.length === 1 && module.dependencyMap[0] === assetsRegistryModuleId)
             requireModule(id)
     }
 }

--- a/libraries/modules/src/metro/caches.ts
+++ b/libraries/modules/src/metro/caches.ts
@@ -10,7 +10,7 @@ import { byProps } from '../filters'
 import { findModule } from '../finders'
 import { ClientInfoModule, FileModule } from '../native'
 import { logger } from '../shared'
-import { blacklistModule, isModuleExportsBad, requireModule } from './index'
+import { requireModule } from './index'
 
 import type { ReactNativeInternals } from '@revenge-mod/revenge'
 import type { Metro } from '../types'

--- a/libraries/modules/src/metro/caches.ts
+++ b/libraries/modules/src/metro/caches.ts
@@ -58,7 +58,7 @@ export const cache = {
      * Registry for module file paths
      * #### This is in-memory.
      */
-    moduleFilePaths: new Map() as Map<Metro.ModuleID, string>,
+    moduleFilePaths: new Map() as Map<string, Metro.ModuleID>,
     /**
      * The total modules count
      */

--- a/libraries/modules/src/metro/index.ts
+++ b/libraries/modules/src/metro/index.ts
@@ -7,7 +7,7 @@ import {
     saveCache,
 } from './caches'
 
-import { IndexMetroModuleId, MetroModuleFlags, MetroModuleLookupFlags } from '../constants'
+import { IndexMetroModuleId, MetroModuleFlags, MetroModuleLookupRegistryFlags } from '../constants'
 
 import { logger } from '../shared'
 
@@ -184,11 +184,11 @@ export function* moduleIdsForFilter(key: string, fullLookup = false) {
     const lookupCache = cache.lookupFlags[key]
 
     if (
-        lookupCache?.flags &&
+        lookupCache?.f &&
         // Check if any modules were found
-        !(lookupCache.flags & MetroModuleLookupFlags.NotFound) &&
+        !(lookupCache.f & MetroModuleLookupRegistryFlags.NotFound) &&
         // Pass immediately if it's not a full lookup, otherwise check if it's a full lookup
-        (!fullLookup || lookupCache.flags & MetroModuleLookupFlags.FullLookup)
+        (!fullLookup || lookupCache.f & MetroModuleLookupRegistryFlags.FullLookup)
     )
         for (const id of cachedModuleIdsForFilter(key)) {
             if (isModuleBlacklisted(id)) continue

--- a/libraries/modules/src/metro/index.ts
+++ b/libraries/modules/src/metro/index.ts
@@ -1,7 +1,7 @@
 import {
     cache,
     cacheModuleAsBlacklisted,
-    indexedModuleIdsForLookup,
+    cachedModuleIdsForFilter,
     requireAssetModules,
     restoreCache,
     saveCache,
@@ -195,10 +195,10 @@ function moduleShouldNotBeHooked(id: Metro.ModuleID) {
 }
 
 /**
- * Yields the modules for a specific finder call
+ * Yields the modules for a specific filter key
  * @param key Filter key
  */
-export function* modulesForFinder(key: string, fullLookup = false) {
+export function* moduleIdsForFilter(key: string, fullLookup = false) {
     const lookupCache = cache.lookupFlags[key]
 
     if (
@@ -208,20 +208,15 @@ export function* modulesForFinder(key: string, fullLookup = false) {
         // Pass immediately if it's not a full lookup, otherwise check if it's a full lookup
         (!fullLookup || lookupCache.flags & MetroModuleLookupFlags.FullLookup)
     )
-        for (const id of indexedModuleIdsForLookup(key)) {
+        for (const id of cachedModuleIdsForFilter(key)) {
             if (isModuleBlacklisted(id)) continue
-            yield [id, requireModule(id)]
+            yield id
         }
-    else {
+    else
         for (const id of modules.keys()) {
             if (isModuleBlacklisted(id)) continue
-
-            const exports = requireModule(id)
-            if (!exports) continue
-
-            yield [id, exports]
+            yield id
         }
-    }
 }
 
 /**
@@ -231,7 +226,7 @@ export function* modulesForFinder(key: string, fullLookup = false) {
  */
 export function isModuleExportsBad(exports: Metro.ModuleExports) {
     return (
-        typeof exports === 'undefined' ||
+        exports === undefined ||
         exports === null ||
         exports === globalThis ||
         exports[''] === null ||

--- a/libraries/modules/src/metro/index.ts
+++ b/libraries/modules/src/metro/index.ts
@@ -37,10 +37,10 @@ function handleModuleInitializeError(id: Metro.ModuleID, error: unknown) {
  * Initializes the Metro modules patches and caches
  */
 export async function initializeModules() {
-    const cacheRestored = await restoreCache()
+    const cacheRestoredPromise = restoreCache()
 
     // Patches modules on load
-    await import('./patches')
+    import('./patches')
 
     function executeModuleSubscriptions(this: Metro.ModuleDefinition) {
         const id = this.publicModule.id
@@ -85,6 +85,8 @@ export async function initializeModules() {
     logger.log('Importing index module...')
     // ! Do NOT use requireModule for this
     __r(IndexMetroModuleId)
+
+    const cacheRestored = await cacheRestoredPromise
 
     // Since cold starts are obsolete, we need to manually import all assets to cache their module IDs as they are imported lazily
     if (!cacheRestored) requireAssetModules()

--- a/libraries/modules/src/metro/index.ts
+++ b/libraries/modules/src/metro/index.ts
@@ -40,7 +40,7 @@ export async function initializeModules() {
     const cacheRestoredPromise = restoreCache()
 
     // Patches modules on load
-    import('./patches')
+    await import('./patches')
 
     function executeModuleSubscriptions(this: Metro.ModuleDefinition) {
         const id = this.publicModule.id

--- a/libraries/modules/src/metro/index.ts
+++ b/libraries/modules/src/metro/index.ts
@@ -83,6 +83,10 @@ export async function initializeModules() {
         }
     }
 
+    logger.log('Importing index module...')
+    // ! Do NOT use requireModule for this
+    if (!modules.get(0)!.isInitialized) __r(0)
+
     const cacheRestored = await cacheRestoredPromise
 
     // Since cold starts are obsolete, we need to manually import all assets to cache their module IDs as they are imported lazily

--- a/libraries/modules/src/metro/index.ts
+++ b/libraries/modules/src/metro/index.ts
@@ -46,9 +46,10 @@ export async function initializeModules() {
         const id = this.publicModule.id
         const exports = this.publicModule.exports
 
+        for (const sub of allSubscriptionsSet) sub(id, exports)
+
         const subs = subscriptions.get(id)
         if (subs) for (const sub of subs) sub(exports)
-        for (const sub of allSubscriptionsSet) sub(id, exports)
     }
 
     for (const [id, module] of modules.entries()) {

--- a/libraries/modules/src/metro/index.ts
+++ b/libraries/modules/src/metro/index.ts
@@ -7,7 +7,7 @@ import {
     saveCache,
 } from './caches'
 
-import { IndexMetroModuleId, MetroModuleFlags, MetroModuleLookupRegistryFlags } from '../constants'
+import { MetroModuleFlags, MetroModuleLookupRegistryFlags } from '../constants'
 
 import { logger } from '../shared'
 
@@ -82,10 +82,6 @@ export async function initializeModules() {
             }
         }
     }
-
-    logger.log('Importing index module...')
-    // ! Do NOT use requireModule for this
-    __r(IndexMetroModuleId)
 
     const cacheRestored = await cacheRestoredPromise
 
@@ -236,6 +232,6 @@ export function isModuleExportsBad(exports: Metro.ModuleExports) {
         exports === null ||
         exports === globalThis ||
         exports[''] === null ||
-        (exports.__proto__ === Object.prototype && Reflect.ownKeys(exports).length === 0)
+        (exports.__proto__ === Object.prototype && !Reflect.ownKeys(exports).length)
     )
 }

--- a/libraries/modules/src/metro/patches.ts
+++ b/libraries/modules/src/metro/patches.ts
@@ -1,7 +1,7 @@
 import { createPatcherInstance } from '@revenge-mod/patcher'
 import { noop, noopPromise } from '@revenge-mod/utils/functions'
 
-import { blacklistModule, getImportingModuleId, isModuleBlacklisted, subscribeModule } from '.'
+import { blacklistModule, getImportingModuleId, isModuleBlacklisted, afterSpecificModuleInitialized, afterModuleInitialized } from '.'
 
 import { cache } from './caches'
 import { logger } from '../shared'
@@ -21,7 +21,7 @@ subscribePatchableModule(
             ([filePath]) => {
                 const importingModuleId = getImportingModuleId()
                 if (importingModuleId === -1 || !filePath) return
-                cache.moduleFilePaths.set(importingModuleId, filePath)
+                cache.moduleFilePaths.set(filePath, importingModuleId)
             },
             'trackFilePath',
         )
@@ -97,10 +97,10 @@ function subscribePatchableModule(
 ) {
     const cachedId = cache.patchableModules[patchId]
     const unsub = cachedId
-        ? subscribeModule(cachedId, exports => {
+        ? afterSpecificModuleInitialized(cachedId, exports => {
               patch(exports, cachedId)
           })
-        : subscribeModule.all((id, exports) => {
+        : afterModuleInitialized((id, exports) => {
               if (!filter(exports, id)) return
               unsub()
 

--- a/libraries/modules/src/metro/patches.ts
+++ b/libraries/modules/src/metro/patches.ts
@@ -30,7 +30,7 @@ const uFFIT = afterModuleInitialized((_, m) => {
 // [NativeStartupFlagsModule, (Problematic), (OtherModule)]
 // We are gonna looking for NativeStartupFlagsModule to blacklist the problematic module
 const uBPM = afterModuleInitialized((id, m) => {
-    if (m.default.reactProfilingEnabled && !modules.get(id + 1)!.isInitialized) {
+    if (m.default?.reactProfilingEnabled && !modules.get(id + 1)!.isInitialized) {
         blacklistModule(id + 1)
         logger.log(`Blacklisted module ${id + 1} as it causes freeze when initialized`)
         uBPM()

--- a/libraries/modules/src/types.d.ts
+++ b/libraries/modules/src/types.d.ts
@@ -126,28 +126,21 @@ export type FilterPredicate<A extends unknown[]> = (
      * The ID of the module
      */
     moduleId: Metro.ModuleID,
-    /**
-     * Whether the returned value should be unmodified
-     */
-    raw: boolean,
 ) => boolean
 
-export interface FilterFn<A extends unknown[]> {
-    (m: ModuleExports, id: number, raw: boolean): boolean
+export type InferFilterFunctionReturnType<F extends FilterFunction<any>> = F extends FilterFunction<infer A, infer T> ? T : never
+
+export type FilterFunction<A extends unknown[], _T = any> = {
+    (m: ModuleExports, id: number): boolean
     filter: FilterPredicate<A>
-    /**
-     * Whether the filter is raw
-     */
-    raw: boolean
     /**
      * The key for the filter
      */
     key: string
 }
 
-export interface Filter<A extends unknown[]> {
-    (...args: A): FilterFn<A>
-    raw(...args: A): FilterFn<A>
+export interface FilterObject<A extends unknown[], T = any> {
+    (...args: A): FilterFunction<A, T>
     /**
      * Generates a unique key for this value
      * @param args The value to generate a key for
@@ -159,12 +152,11 @@ export interface Filter<A extends unknown[]> {
 
 /** @internal */
 export interface LazyModuleContext<A extends unknown[] = unknown[]> {
-    filter: FilterFn<A>
-    getModuleId(): number | undefined
-    getExports(cb: (exports: ModuleExports) => void): () => void
+    filter?: FilterFunction<A>
+    moduleId(): number | undefined
+    exports(cb: (exports: ModuleExports) => void): () => void
     subscribe(cb: (exports: ModuleExports) => void): () => void
-    forceLoad(): ModuleExports
-    get cache(): ModuleExports
+    factory(): ModuleExports
 }
 
 export type LazyModule<T> = T extends unknown | undefined
@@ -317,6 +309,7 @@ export namespace DiscordModules {
      * Logs will be shown in the **Debug Logs** section in settings
      */
     export class Logger {
+        static name: string
         constructor(tag: string)
         log(...args: unknown[]): void
         error(...args: unknown[]): void

--- a/libraries/modules/src/utils/filters.ts
+++ b/libraries/modules/src/utils/filters.ts
@@ -1,31 +1,25 @@
-import type { Filter, FilterPredicate, Metro } from '../types'
+import type { FilterObject, FilterFunction, FilterPredicate, Metro } from '../types'
 
 export function createFilter<A extends unknown[]>(
     predicate: FilterPredicate<A>,
     keyFor: (args: A) => string,
-): Filter<A> {
-    const createHolder = <T extends (m: Metro.ModuleExports, id: number, raw: boolean) => ReturnType<typeof predicate>>(
-        func: T,
-        args: A,
-        raw: boolean,
-    ) => {
-        return Object.assign(func, {
-            filter: predicate,
-            raw,
-            key: `${raw ? 'raw:' : ''}${keyFor(args)}`,
-        })
-    }
-
-    const curry =
-        (raw: boolean) =>
-        (...args: A) => {
-            return createHolder((m, id, raw) => predicate(args, m, id, raw), args, raw)
-        }
-
-    return Object.assign(curry(false), {
-        raw: curry(true),
-        keyFor,
-    })
+): FilterObject<A> {
+    return Object.assign(
+        (...args: A) =>
+            Object.assign(
+                ((m, id) => predicate(args, m, id)) satisfies (
+                    m: Metro.ModuleExports,
+                    id: number,
+                ) => ReturnType<typeof predicate>,
+                {
+                    filter: predicate,
+                    key: keyFor(args),
+                },
+            ) satisfies FilterFunction<A>,
+        {
+            keyFor,
+        },
+    )
 }
 
 export function createSimpleFilter(predicate: (m: Metro.ModuleExports) => boolean, key: string) {

--- a/libraries/modules/src/utils/filters.ts
+++ b/libraries/modules/src/utils/filters.ts
@@ -26,5 +26,5 @@ export function createSimpleFilter(predicate: (m: Metro.ModuleExports) => boolea
     return createFilter(
         (_, m) => predicate(m),
         () => `dyn:${key}`,
-    )()
+    )
 }

--- a/libraries/modules/src/utils/lazy.ts
+++ b/libraries/modules/src/utils/lazy.ts
@@ -1,47 +1,95 @@
 import { patcherLazyModuleSymbol } from '@revenge-mod/patcher'
 import { noop } from '@revenge-mod/utils/functions'
 import { lazyValue } from '@revenge-mod/utils/lazy'
-import { find } from '../finders'
-import { subscribeModule } from '../metro'
-import { cache, indexedModuleIdsForLookup } from '../metro/caches'
 
-import type { FilterFn, LazyModuleContext, Metro } from '../types'
+import { findEager, type FinderOptions, type LazyFinderOptions } from '../finders'
+
+import { requireModule, subscribeModule } from '../metro'
+import { cache, cachedModuleIdsForFilter } from '../metro/caches'
+
+import type { FilterFunction, InferFilterFunctionReturnType, LazyModule, LazyModuleContext, Metro } from '../types'
 
 export const lazyContextSymbol = Symbol.for('revenge.modules.lazyContext')
-const lazyContexts = new WeakMap<Metro.ModuleExports, LazyModuleContext>()
+const lazyContexts = new WeakMap<LazyModule<any>, LazyModuleContext>()
 
-export function subscribeModuleLazy(proxy: Metro.ModuleExports, callback: (exports: Metro.ModuleExports) => void) {
+export function subscribeModuleLazy(
+    proxy: Metro.ModuleExports,
+    callback: (exports: Metro.ModuleExports) => void,
+    options?: FinderOptions,
+) {
     const info = getLazyContext(proxy)
     if (!info) throw new Error('No lazy module attached to this proxy')
 
-    const moduleId = info?.getModuleId()
+    const moduleId = info.moduleId()
     if (!moduleId)
         throw new Error(
-            `Lazy module has no module ID attached, check if your filter matches any modules: ${info.filter.key}`,
+            `Lazy module has no module ID attached, check if your filter matches any modules: ${info.filter?.key}`,
         )
 
-    return subscribeModule(moduleId, () => callback(find.eager(info.filter)))
+    return subscribeModule(moduleId, (_, exports) => callback(info.filter ? findEager(info.filter, options) : exports))
 }
 
 function getLazyContext<A extends unknown[]>(proxy: Metro.ModuleExports): LazyModuleContext<A> | undefined {
     return lazyContexts.get(proxy) as LazyModuleContext<A> | undefined
 }
 
-export function createLazyModule<A extends unknown[]>(filter: FilterFn<A>) {
-    const moduleIds = indexedModuleIdsForLookup(filter.key)
+export function createLazyModuleById<F extends FilterFunction<any[]>>(moduleId: number, options?: LazyFinderOptions) {
+    let cachedValue: Metro.ModuleExports
+
+    const context: LazyModuleContext<Parameters<F>> = {
+        moduleId: () => moduleId,
+        exports(cb) {
+            this.factory()
+
+            if (cachedValue) {
+                cb(cachedValue)
+                return noop
+            }
+
+            return this.subscribe(cb)
+        },
+        subscribe(cb) {
+            return subscribeModuleLazy(proxy, cb, options)
+        },
+        factory() {
+            if (cachedValue === undefined) {
+                const exports = requireModule(moduleId)
+                if (exports) cachedValue = !options?.returnWholeModule && exports.__esModule ? exports.default : exports
+            }
+
+            return cachedValue
+        },
+    }
+
+    const proxy = lazyValue(() => context.factory() as NonNullable<InferFilterFunctionReturnType<F>>, {
+        ...options,
+        exemptedEntries: {
+            ...options?.lazyOptions?.exemptedEntries,
+            [lazyContextSymbol]: context,
+            [patcherLazyModuleSymbol]: (cb: (exports: Metro.ModuleExports) => void) => context.exports(cb),
+        },
+    })
+
+    lazyContexts.set(proxy, context as LazyModuleContext<Metro.ModuleExports>)
+
+    return proxy
+}
+
+export function createLazyModule<F extends FilterFunction<any[]>>(filter: F, options?: LazyFinderOptions) {
+    const moduleIds = cachedModuleIdsForFilter(filter.key)
     let moduleId: number | undefined
     let cachedValue: Metro.ModuleExports
 
-    const context: LazyModuleContext<A> = {
+    const context: LazyModuleContext<Parameters<F>> = {
         filter,
-        getModuleId: () => moduleId,
-        getExports(cb) {
+        moduleId: () => moduleId,
+        exports(cb) {
             for (const id of moduleIds) {
                 moduleId = id
 
-                // If the module hasn't been indexed, or it has already been initialized (indexed is inferred)
+                // If the module has already been initialized
                 if (modules.get(moduleId)?.isInitialized) {
-                    if (!cachedValue && !this.forceLoad()) {
+                    if (!cachedValue && !this.factory()) {
                         // This module apparently doesn't exist, so we remove it from the cache
                         delete cache.lookupFlags[filter.key]?.[moduleId]
                         continue
@@ -58,7 +106,7 @@ export function createLazyModule<A extends unknown[]>(filter: FilterFn<A>) {
                 return this.subscribe(cb)
             }
 
-            if (cachedValue || this.forceLoad()) {
+            if (cachedValue || this.factory()) {
                 cb(cachedValue)
                 return noop
             }
@@ -68,21 +116,20 @@ export function createLazyModule<A extends unknown[]>(filter: FilterFn<A>) {
             return noop
         },
         subscribe(cb) {
-            return subscribeModuleLazy(proxy, cb)
+            return subscribeModuleLazy(proxy, cb, options)
         },
-        get cache() {
-            return cachedValue
-        },
-        forceLoad() {
-            cachedValue ??= find.eager(filter)
+        factory() {
+            cachedValue ??= findEager(filter, options)
             return cachedValue
         },
     }
 
-    const proxy = lazyValue(() => context.forceLoad(), {
+    const proxy = lazyValue(() => context.factory() as NonNullable<InferFilterFunctionReturnType<F>>, {
+        ...options?.lazyOptions,
         exemptedEntries: {
+            ...options?.lazyOptions?.exemptedEntries,
             [lazyContextSymbol]: context,
-            [patcherLazyModuleSymbol]: (cb: (exports: Metro.ModuleExports) => void) => context.getExports(cb),
+            [patcherLazyModuleSymbol]: (cb: (exports: Metro.ModuleExports) => void) => context.exports(cb),
         },
     })
 

--- a/libraries/modules/src/utils/lazy.ts
+++ b/libraries/modules/src/utils/lazy.ts
@@ -5,7 +5,7 @@ import { lazyValue } from '@revenge-mod/utils/lazy'
 import { findEager, type FinderOptions, type LazyFinderOptions } from '../finders'
 
 import { requireModule, afterSpecificModuleInitialized } from '../metro'
-import { cache, cachedModuleIdsForFilter } from '../metro/caches'
+import { cachedModuleIdsForFilter } from '../metro/caches'
 
 import type { FilterFunction, InferFilterFunctionReturnType, LazyModule, LazyModuleContext, Metro } from '../types'
 
@@ -56,7 +56,7 @@ export function createLazyModuleById<F extends FilterFunction<any[]>>(moduleId: 
         factory() {
             if (cachedValue === undefined) {
                 const exports = requireModule(moduleId)
-                if (exports) cachedValue = !options?.returnWholeModule && exports.__esModule ? exports.default : exports
+                if (exports) cachedValue = !options?.wildcard && exports.__esModule ? exports.default : exports
             }
 
             return cachedValue
@@ -91,11 +91,8 @@ export function createLazyModule<F extends FilterFunction<any[]>>(filter: F, opt
 
                 // If the module has already been initialized
                 if (modules.get(moduleId)?.isInitialized) {
-                    if (!cachedValue && !this.factory()) {
-                        // This module apparently doesn't exist, so we remove it from the cache
-                        delete cache.lookupFlags[filter.key]?.[moduleId]
-                        continue
-                    }
+                    // TODO: Invalidate cache when this happens
+                    if (!cachedValue && !this.factory()) continue
 
                     cb(cachedValue)
                     return noop

--- a/libraries/modules/src/utils/lazy.ts
+++ b/libraries/modules/src/utils/lazy.ts
@@ -4,7 +4,7 @@ import { lazyValue } from '@revenge-mod/utils/lazy'
 
 import { findEager, type FinderOptions, type LazyFinderOptions } from '../finders'
 
-import { requireModule, subscribeModule } from '../metro'
+import { requireModule, afterSpecificModuleInitialized } from '../metro'
 import { cache, cachedModuleIdsForFilter } from '../metro/caches'
 
 import type { FilterFunction, InferFilterFunctionReturnType, LazyModule, LazyModuleContext, Metro } from '../types'
@@ -26,7 +26,9 @@ export function subscribeModuleLazy(
             `Lazy module has no module ID attached, check if your filter matches any modules: ${info.filter?.key}`,
         )
 
-    return subscribeModule(moduleId, (_, exports) => callback(info.filter ? findEager(info.filter, options) : exports))
+    return afterSpecificModuleInitialized(moduleId, exports =>
+        callback(info.filter ? findEager(info.filter, options) : exports),
+    )
 }
 
 function getLazyContext<A extends unknown[]>(proxy: Metro.ModuleExports): LazyModuleContext<A> | undefined {

--- a/libraries/patcher/src/types.d.ts
+++ b/libraries/patcher/src/types.d.ts
@@ -1,4 +1,5 @@
 import type { Metro } from '@revenge-mod/modules'
+import type { AnyObject } from '@revenge-mod/shared/types'
 
 type WrappableName = 'after' | 'before' | 'instead'
 type UnpatchFunction = () => boolean
@@ -7,8 +8,8 @@ type SafeParameters<T> = T extends (...args: infer P) => any ? P : any[]
 
 type KeysWithFunctionValues<T extends AnyObject> = {
     // biome-ignore lint/complexity/noBannedTypes: Would you shut up please?
-    [K in Extract<keyof T, string>]: T[K] extends Function ? K : never
-}[Extract<keyof T, string>]
+    [K in keyof T]: T[K] extends Function ? K : never
+}[keyof T]
 
 type WrappableParams<N extends WrappableName, Parent extends AnyObject, Name extends KeysWithFunctionValues<Parent>> = [
     /**

--- a/libraries/patcher/src/utils.ts
+++ b/libraries/patcher/src/utils.ts
@@ -5,7 +5,7 @@ type CallableFunction = (...args: any[]) => any
 
 export function createExtendedPatchFunction<N extends WrappableName>(fn: CallableFunction) {
     function patchFn(this: any, ...args: any) {
-        if (patcherLazyModuleSymbol in args[0]) {
+        if (args[0][patcherLazyModuleSymbol]) {
             const onceModuleLoaded = args[0][patcherLazyModuleSymbol] as OnceModuleLoadedCallback
 
             let cancel = false
@@ -25,7 +25,7 @@ export function createExtendedPatchFunction<N extends WrappableName>(fn: Callabl
 
     function promisePatchFn(this: any, ...args: [Promise<any>, ...any[]]) {
         const thenable = args[0]
-        if (!thenable || !('then' in thenable)) throw new Error('Cannot await a non-thenable object')
+        if (!thenable || !thenable.then) throw new Error('Cannot await a non-thenable object')
 
         let cancel = false
         let unpatch = () => (cancel = true)

--- a/libraries/plugins/src/index.ts
+++ b/libraries/plugins/src/index.ts
@@ -47,7 +47,7 @@ export async function installPlugin(uri: string, trustUnsigned = false) {
 
         try {
             const manifest = parseSchema(PluginManifestSchema, JSON.parse(new TextDecoder().decode(manifestJson)))
-            if (manifest.id in registeredPlugins) return InstallPluginResult.AlreadyInstalled
+            if (registeredPlugins[manifest.id]) return InstallPluginResult.AlreadyInstalled
 
             if (!sourceZipSig || !publicKey) {
                 if (!trustUnsigned) return InstallPluginResult.PluginUnsigned
@@ -96,7 +96,7 @@ export function clearPluginStorage(id: string) {
 }
 
 export async function uninstallPlugin(id: string) {
-    if (id in registeredPlugins) {
+    if (registeredPlugins[id]) {
         const plugin = registeredPlugins[id]!
         if (!plugin.external) throw new Error(`Cannot uninstall internal plugin: ${plugin.id}`)
 
@@ -105,7 +105,7 @@ export async function uninstallPlugin(id: string) {
         delete registeredPlugins[id]
     }
 
-    if (!(id in externalPluginsMetadata)) throw new Error(`Plugin "${id}" is not installed`)
+    if (!externalPluginsMetadata[id]) throw new Error(`Plugin "${id}" is not installed`)
 
     delete externalPluginsMetadata[id]
     delete pluginsStates[id]

--- a/libraries/plugins/src/internals.ts
+++ b/libraries/plugins/src/internals.ts
@@ -47,7 +47,7 @@ export function registerPlugin<
     definition: PluginDefinition<Storage, AppLaunchedReturn, AppInitializedReturn>,
     opts: RegisterPluginOptions = {},
 ) {
-    if (manifest.id in registeredPlugins) throw new Error(`Plugin "${manifest.id}" is already registered`)
+    if (registeredPlugins[manifest.id]) throw new Error(`Plugin "${manifest.id}" is already registered`)
 
     const external = opts.external ?? true
     const options: Required<RegisterPluginOptions> = {

--- a/libraries/plugins/src/internals.ts
+++ b/libraries/plugins/src/internals.ts
@@ -1,5 +1,5 @@
 import { afterAppRender, isAppRendered } from '@revenge-mod/app'
-import { subscribeModule } from '@revenge-mod/modules/metro'
+import { afterModuleInitialized } from '@revenge-mod/modules/metro'
 import { createPatcherInstance } from '@revenge-mod/patcher'
 import { DefaultPluginStopConfig, PluginStatus, WhitelistedPluginObjectKeys } from '@revenge-mod/plugins/constants'
 import { type PluginStates, pluginsStates } from '@revenge-mod/preferences'
@@ -77,7 +77,7 @@ export function registerPlugin<
                 ? () => {
                       def.lifecycles.prepare()
 
-                      const unsub = subscribeModule.all((id, exports) =>
+                      const unsub = afterModuleInitialized((id, exports) =>
                           definition.onMetroModuleLoad!(ctx, id, exports, unsub),
                       )
 

--- a/libraries/react/package.json
+++ b/libraries/react/package.json
@@ -4,8 +4,5 @@
   "scripts": {},
   "exports": {
     "./jsx": "./src/jsx.ts"
-  },
-  "dependencies": {
-    "@revenge-mod/patcher": "workspace:*"
   }
 }

--- a/libraries/react/src/jsx.ts
+++ b/libraries/react/src/jsx.ts
@@ -42,7 +42,7 @@ const patchCallback = (
     if (!name) return orig.apply(ReactJSXRuntime, args)
 
     let newArgs = args
-    if (name in beforeCallbacks)
+    if (beforeCallbacks[name])
         for (const cb of beforeCallbacks[name]!) {
             const maybeArgs = cb(newArgs as [ElementType, ComponentProps<ElementType>, string | undefined])
             if (maybeArgs) newArgs = maybeArgs
@@ -50,7 +50,7 @@ const patchCallback = (
 
     let tree = orig.apply(ReactJSXRuntime, newArgs)
 
-    if (name in afterCallbacks) {
+    if (afterCallbacks[name]) {
         for (const cb of afterCallbacks[name]!) {
             const maybeTree = cb(Comp, props, tree)
             if (typeof maybeTree !== 'undefined') tree = maybeTree!

--- a/libraries/react/src/jsx.ts
+++ b/libraries/react/src/jsx.ts
@@ -25,7 +25,7 @@ const patchCallback = (
     // Hopefully fixes iOS "invalid element type" issue after patching ErrorBoundary
     // Comp can be undefined for some reason
     // @ts-expect-error
-    if (typeof (Comp?.type ?? Comp) === 'undefined') {
+    if ((Comp?.type ?? Comp) === undefined) {
         args[0] = 'RCTView' as keyof JSX.IntrinsicElements
         args[1] = { style: styles.hidden } satisfies ViewProps
         return orig.apply(ReactJSXRuntime, args)

--- a/libraries/react/src/shared.ts
+++ b/libraries/react/src/shared.ts
@@ -1,3 +1,0 @@
-import { createPatcherInstance } from '@revenge-mod/patcher'
-
-export const patcher = createPatcherInstance('revenge.react')

--- a/libraries/ui/src/colors.ts
+++ b/libraries/ui/src/colors.ts
@@ -2,7 +2,10 @@ import { tokens } from '@revenge-mod/modules/common'
 import { ThemeStore } from '@revenge-mod/modules/common/stores'
 import { lazyValue } from '@revenge-mod/utils/lazy'
 
-export const SemanticColor = lazyValue(() => tokens.colors, { hint: 'object' }) as Record<string, symbol & { __TYPE__: 'Color' }>
+export const SemanticColor = lazyValue(() => tokens.colors, { hint: 'object' }) as Record<
+    string,
+    symbol & { __TYPE__: 'Color' }
+>
 export const RawColor = lazyValue(() => tokens.unsafe_rawColors, { hint: 'object' }) as Record<string, string>
 
 export function isSemanticColor(key: string): boolean {

--- a/libraries/ui/src/settings.ts
+++ b/libraries/ui/src/settings.ts
@@ -21,7 +21,7 @@ export const SettingsUILibrary = {
 export type SettingsUILibrary = typeof SettingsUILibrary
 
 function createSettingsSection(section: (typeof customData.sections)[string]) {
-    if (section.name in customData.sections)
+    if (customData.sections[section.name])
         throw new Error(`The settings section with the name "${section.name}" already exists`)
     customData.sections[section.name] = section
     return () => delete customData.sections[section.name]
@@ -33,7 +33,7 @@ function createSettingsRoute(key: string, route: RouteRowConfig) {
 }
 
 function addSettingsRowsToSection(name: string, rows: Record<string, RowConfig>) {
-    if (!(name in customData.sections)) throw new Error(`No setting section exists with the name "${name}"`)
+    if (!customData.sections[name]) throw new Error(`No setting section exists with the name "${name}"`)
     const section = customData.sections[name]
     Object.assign(section!.settings, rows)
     return () => {

--- a/libraries/utils/src/lazy.ts
+++ b/libraries/utils/src/lazy.ts
@@ -1,4 +1,4 @@
-export type ExemptedEntries = Record<symbol | string, unknown>
+export type ExemptedEntries = Record<symbol | string, any>
 
 export interface LazyOptions<E extends ExemptedEntries = ExemptedEntries> {
     hint?: 'function' | 'object'

--- a/libraries/utils/src/lazy.ts
+++ b/libraries/utils/src/lazy.ts
@@ -5,8 +5,8 @@ export interface LazyOptions<E extends ExemptedEntries = ExemptedEntries> {
     exemptedEntries?: E
 }
 
-const unconfigurable = new Set(['arguments', 'caller', 'prototype'])
-const isUnconfigurable = (key: PropertyKey) => typeof key === 'string' && unconfigurable.has(key)
+const unconfigurable = new Set<string | symbol>(['arguments', 'caller', 'prototype'])
+const isUnconfigurable = (key: string | symbol) => unconfigurable.has(key)
 
 const factories = new WeakMap<any, () => any>()
 const proxyContextHolder = new WeakMap<

--- a/libraries/utils/src/lazy.ts
+++ b/libraries/utils/src/lazy.ts
@@ -88,7 +88,7 @@ const lazyHandler: ProxyHandler<any> = {
  * @param opts.hint Hint for the lazy proxy, if it's an object or a function (default `'function'`)
  * @param opts.exemptedEntries Exempted entries that will be returned directly from the specified values
  * @returns A proxy that will call the factory function only when needed
- * @example const ChannelStore = lazyValue(() => findByProps.eager("getChannelId"));
+ * @example const ChannelStore = lazyValue(() => findEager(byProps("getChannelId")));
  */
 export function lazyValue<T, I extends ExemptedEntries>(factory: () => T, opts: LazyOptions<I> = {}): T {
     let cache: T
@@ -118,7 +118,7 @@ export function lazyValue<T, I extends ExemptedEntries>(factory: () => T, opts: 
  * @param opts Options for the lazy destructure
  * @example
  *
- * const { uuid4 } = lazyDestructure(() => findByProps.eager("uuid4"))
+ * const { uuid4 } = lazyDestructure(() => findEager(byProps("uuid4")))
  * uuid4; // <- is a lazy value!
  */
 export function lazyDestructure<T extends Record<PropertyKey, unknown>, I extends ExemptedEntries>(

--- a/libraries/utils/src/observables.ts
+++ b/libraries/utils/src/observables.ts
@@ -1,11 +1,13 @@
 import { Observable, type Observer, type ObserverOptions } from '@gullerya/object-observer'
 import { useRerenderer } from '@revenge-mod/utils/hooks'
 
+import { useEffect } from 'react'
+
 export function useObserve(observables: Observable[], opts?: ObserverOptions) {
     const rerender = useRerenderer()
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: We manually re-render when needed
-    React.useEffect(() => {
+    useEffect(() => {
         for (const o of observables) Observable.observe(o, rerender, opts)
 
         return () => {
@@ -22,7 +24,7 @@ export function useObserveFiltered(
     const rerender = useRerenderer()
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: We manually re-render when needed
-    React.useEffect(() => {
+    useEffect(() => {
         const listener: Observer = changes => filter(changes) && rerender()
         Observable.observe(observable, listener, opts)
 

--- a/libraries/utils/src/react.ts
+++ b/libraries/utils/src/react.ts
@@ -1,10 +1,10 @@
-import type { ReactNode } from 'react'
+import { useEffect, type ReactNode } from 'react'
 import { type SearchFilter, findInTree } from './trees'
 
 export function useIsFirstRender() {
     let firstRender = false
     // biome-ignore lint/correctness/useExhaustiveDependencies: Not needed
-    React.useEffect(() => void (firstRender = true), [])
+    useEffect(() => void (firstRender = true), [])
     return firstRender
 }
 

--- a/libraries/utils/src/zip.ts
+++ b/libraries/utils/src/zip.ts
@@ -1,5 +1,5 @@
 import { unzipSync } from 'fflate/browser'
-import { Platform } from 'react-native'
+import { NativeModules, Platform } from 'react-native'
 
 export function parseZip(buf: ArrayBuffer | Uint8Array) {
     return unzipSync(buf instanceof Uint8Array ? buf : new Uint8Array(buf))
@@ -33,7 +33,7 @@ export async function parseZipFromURI(uri: string, options?: ParseZipFromURIOpti
 
     try {
         if (Platform.OS === 'android' && uri.startsWith('content://')) {
-            const fs = ReactNative.NativeModules.RNFSManager
+            const fs = NativeModules.RNFSManager
 
             const b64 = await fs.readFile(uri)
             return unzipSync(Buffer.from(b64, 'base64'))

--- a/shims/deps.ts
+++ b/shims/deps.ts
@@ -4,13 +4,15 @@ const findByProps = (...props: string[]) => {
     return find(byProps(...props))
 }
 
+const findByPropsEager = (...props: string[]) => {
+    const { findEager } = require('@revenge-mod/modules/finders')
+    const { byProps } = require('@revenge-mod/modules/filters')
+    return findEager(byProps(...props))
+}
+
 export default {
-    react: () => (globalThis.React = findByProps('createElement')!),
-    'react-native': () => (globalThis.ReactNative = findByProps('AppRegistry')!),
-    util: () => findByProps('inspect', 'isNullOrUndefined'),
-    moment: () => findByProps('isMoment'),
-    'chroma-js': () => findByProps('brewer'),
+    react: () => findByPropsEager('createElement')!,
+    'react-native': () => findByPropsEager('AppRegistry')!,
     lodash: () => findByProps('forEachRight'),
-    '@shopify/react-native-skia': () => findByProps('useFont'),
     '@shopify/flash-list': () => findByProps('FlashList'),
 }

--- a/shims/deps.ts
+++ b/shims/deps.ts
@@ -1,15 +1,16 @@
-const lazyFindByProps = (...props: string[]) => {
-    const { findByProps } = require('@revenge-mod/modules/finders')
-    return findByProps(...props)
+const findByProps = (...props: string[]) => {
+    const { find } = require('@revenge-mod/modules/finders')
+    const { byProps } = require('@revenge-mod/modules/filters')
+    return find(byProps(...props))
 }
 
 export default {
-    react: () => (globalThis.React = lazyFindByProps('createElement')!),
-    'react-native': () => (globalThis.ReactNative = lazyFindByProps('AppRegistry')!),
-    util: () => lazyFindByProps('inspect', 'isNullOrUndefined'),
-    moment: () => lazyFindByProps('isMoment'),
-    'chroma-js': () => lazyFindByProps('brewer'),
-    lodash: () => lazyFindByProps('forEachRight'),
-    '@shopify/react-native-skia': () => lazyFindByProps('useFont'),
-    '@shopify/flash-list': () => lazyFindByProps('FlashList'),
+    react: () => (globalThis.React = findByProps('createElement')!),
+    'react-native': () => (globalThis.ReactNative = findByProps('AppRegistry')!),
+    util: () => findByProps('inspect', 'isNullOrUndefined'),
+    moment: () => findByProps('isMoment'),
+    'chroma-js': () => findByProps('brewer'),
+    lodash: () => findByProps('forEachRight'),
+    '@shopify/react-native-skia': () => findByProps('useFont'),
+    '@shopify/flash-list': () => findByProps('FlashList'),
 }

--- a/shims/react~jsx-runtime.ts
+++ b/shims/react~jsx-runtime.ts
@@ -1,9 +1,10 @@
 import '@revenge-mod/modules'
+import { byProps } from '@revenge-mod/modules/filters'
 
-import { findByProps } from '@revenge-mod/modules/finders'
+import { find } from '@revenge-mod/modules/finders'
 import { getProxyFactory } from '@revenge-mod/utils/lazy'
 
-const jsxRuntime = findByProps<typeof import('react/jsx-runtime')>('jsx', 'jsxs', 'Fragment')!
+const jsxRuntime = find(byProps<typeof import('react/jsx-runtime')>('jsx', 'jsxs', 'Fragment'))!
 
 function unproxyFirstArg<T>(args: T[]) {
     if (!args[0]) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,61 @@
 // So objectSeal and objectFreeze contain the proper functions before we overwrite them
 import '@revenge-mod/utils/functions'
 
-import { createLogger } from '@revenge-mod/utils/library'
-
-import { IndexMetroModuleId } from '@revenge-mod/modules/constants'
-import { ClientInfoModule } from '@revenge-mod/modules/native'
-import { createPatcherInstance } from '@revenge-mod/patcher'
 import { getErrorStack } from '@revenge-mod/utils/errors'
+import { createLogger } from '@revenge-mod/utils/library'
 
 import type { Metro } from '@revenge-mod/modules'
 
 Object.freeze = Object.seal = o => o
 
-// ! This function is BLOCKING, so we need to make sure it's as fast as possible
+async function onError(e: unknown) {
+    const { ClientInfoModule } = await import('@revenge-mod/modules/native')
+
+    logger.error(`Failed to load Revenge: ${getErrorStack(e)}`)
+    alert(['Failed to load Revenge\n', `Build Number: ${ClientInfoModule.Build}`, getErrorStack(e)].join('\n'))
+}
+
+function onceIndexRequired() {
+    // Hermes doesn't natively support Promises, it instead has a polyfill for it which doesn't handle rejections very well
+    // It doesn't throw and never logs in a non-development environment, we are patching it to do so, so we can catch errors when using async functions
+    // https://github.com/facebook/hermes/blob/3332fa020cae0bab751f648db7c94e1d687eeec7/lib/InternalBytecode/01-Promise.js#L446
+    const ErrorTypeWhitelist = [ReferenceError, TypeError, RangeError]
+    Promise._m = (promise, err) => {
+        // If the rejections are useful enough, we log them
+        if (err)
+            setTimeout(
+                () => {
+                    if (promise._h === 0) logger.error(`Unhandled promise rejection: ${getErrorStack(err)}`)
+                },
+                ErrorTypeWhitelist.some(it => err instanceof it) ? 0 : 2000,
+                // The time is completely arbitary. I've picked what Hermes chose.
+            )
+    }
+
+    const batchedBridge = __fbBatchedBridge
+    const callQueue: any[] = []
+
+    const origCFRFQ = batchedBridge.callFunctionReturnFlushedQueue
+    batchedBridge.callFunctionReturnFlushedQueue = (...args) => {
+        // Holding AppRegistry calls until we're ready (patches completed)
+        // or if the module doesn't exist yet, we also hold it
+        if (args[0] === 'AppRegistry' || !batchedBridge.getCallableModule(args[0])) {
+            callQueue.push(args)
+            return batchedBridge.flushedQueue()
+        }
+
+        return origCFRFQ.apply(batchedBridge, args)
+    }
+
+    initialize()
+        .then(() => {
+            batchedBridge.callFunctionReturnFlushedQueue = origCFRFQ
+            for (const queue of callQueue) batchedBridge.__callFunction(...queue)
+        })
+        .catch(onError)
+}
+
+// ! This function is BLOCKING AppRegistry calls, so we need to make sure it's as fast as possible
 async function initialize() {
     try {
         const { createModulesLibrary } = await import('@revenge-mod/modules')
@@ -63,83 +106,37 @@ async function initialize() {
     }
 }
 
-function onError(e: unknown) {
-    logger.error(`Failed to load Revenge: ${getErrorStack(e)}`)
-    alert(['Failed to load Revenge\n', `Build Number: ${ClientInfoModule.Build}`, getErrorStack(e)].join('\n'))
-}
+let require: Metro.RequireFn | undefined = globalThis.__r as typeof __r | undefined
+// This rarely happens, but if __r is already set, that means we can initialize immediately
+if (require) initialize()
 
-let requireFunc: Metro.RequireFn | undefined
-
-const patcher = createPatcherInstance('revenge.library.init')
-const logger = createLogger('init')
-
-// Hermes doesn't natively support Promises, it instead has a polyfill for it which doesn't handle rejections very well
-// It doesn't throw and never logs in a non-development environment, we are patching it to do so, so we can catch errors when using async functions
-// https://github.com/facebook/hermes/blob/3332fa020cae0bab751f648db7c94e1d687eeec7/lib/InternalBytecode/01-Promise.js#L446
-const ErrorTypeWhitelist = [ReferenceError, TypeError, RangeError]
-Promise._m = (promise, err) => {
-    // If the rejections are useful enough, we log them
-    if (err)
-        setTimeout(
-            () => {
-                if (promise._h === 0) logger.error(`Unhandled promise rejection: ${getErrorStack(err)}`)
-            },
-            ErrorTypeWhitelist.some(it => err instanceof it) ? 0 : 2000,
-            // The time is completely arbitary. I've picked what Hermes chose.
-        )
-}
-
-if (typeof __r !== 'undefined') initialize()
-
-// We hold calls from the native side
-function onceIndexRequired() {
-    const batchedBridge = __fbBatchedBridge
-
-    const callQueue: any[] = []
-    const unpatch = patcher.instead(
-        batchedBridge,
-        'callFunctionReturnFlushedQueue',
-        (args, orig) => {
-            if (args[0] === 'AppRegistry' || !batchedBridge.getCallableModule(args[0])) {
-                callQueue.push(args)
-                return batchedBridge.flushedQueue()
-            }
-
-            return orig.apply(batchedBridge, args)
-        },
-        'holdNativeCalls',
-    )
-
-    initialize()
-        .then(() => {
-            unpatch()
-            for (const queue of callQueue)
-                batchedBridge.getCallableModule(queue[0]) && batchedBridge.__callFunction(...queue)
-        })
-        .catch(onError)
-}
+let define: Metro.DefineFn | undefined
 
 Object.defineProperties(globalThis, {
     __r: {
         configurable: true,
-        get: () => requireFunc,
-        set(metroRequire) {
-            requireFunc = function patchedRequire(id: number) {
-                if (id === IndexMetroModuleId) {
-                    requireFunc = metroRequire
-                    onceIndexRequired()
-                } else return metroRequire(id)
-            }
+        get: () => require,
+        set: metroRequire => {
+            require = (id: number) =>
+                id
+                    ? // Early modules (React, React Native, polyfills, etc.) are required even before index (module 0) is required
+                      metroRequire(id)
+                    : // Once index is required, we initialize our patches
+                      // biome-ignore lint/style/noCommaOperator: It is allowed now
+                      (Object.defineProperty(globalThis, '__r', { value: metroRequire }), onceIndexRequired())
         },
     },
     __d: {
         configurable: true,
-        get() {
-            globalThis.modules ??= __c?.()
-            return this.value
+        get: () => {
+            Object.defineProperty(globalThis, '__d', { value: define })
+            globalThis.modules = __c!()
+            return define
         },
-        set(v) {
-            this.value = v
+        set: v => {
+            define = v
         },
     },
 })
+
+const logger = createLogger('init')

--- a/src/plugins/developer-settings/index.tsx
+++ b/src/plugins/developer-settings/index.tsx
@@ -4,6 +4,8 @@ import { toasts } from '@revenge-mod/modules/common'
 import { registerPlugin } from '@revenge-mod/plugins/internals'
 import { sleep } from '@revenge-mod/utils/functions'
 
+import { createContext, type FunctionComponent } from 'react'
+
 import AssetBrowserSettingsPage from './pages/AssetBrowser'
 import DeveloperSettingsPage from './pages/Developer'
 
@@ -12,7 +14,6 @@ import { DevToolsEvents, connectToDevTools, disconnectFromDevTools } from './dev
 
 import { BundleUpdaterManager } from '@revenge-mod/modules/native'
 import type { PluginContextFor } from '@revenge-mod/plugins'
-import type { FunctionComponent } from 'react'
 
 const plugin = registerPlugin<{
     reactDevTools: {
@@ -165,4 +166,4 @@ function setupDebugger({ patcher, cleanup }: PluginContextFor<typeof plugin, 'Af
     )
 }
 
-export const PluginContext = React.createContext<PluginContextFor<typeof plugin, 'AfterAppRender'>>(null!)
+export const PluginContext = createContext<PluginContextFor<typeof plugin, 'AfterAppRender'>>(null!)

--- a/src/plugins/settings/index.tsx
+++ b/src/plugins/settings/index.tsx
@@ -127,7 +127,7 @@ const plugin = registerPlugin<Storage>(
             await sleep(0)
 
             const SettingsConstants = find(byProps('SETTING_RENDERER_CONFIG'))!
-            const SettingsOverviewScreen = find(byName<FC & { name: string }>('SettingsOverviewScreen'), { returnWholeModule: true })!
+            const SettingsOverviewScreen = find(byName<FC & { name: string }>('SettingsOverviewScreen'), { wildcard: true })!
 
             const originalRendererConfig = SettingsConstants.SETTING_RENDERER_CONFIG as Record<string, RawRowConfig>
             let rendererConfig = originalRendererConfig

--- a/src/plugins/settings/index.tsx
+++ b/src/plugins/settings/index.tsx
@@ -46,7 +46,13 @@ const plugin = registerPlugin<Storage>(
                 patcher,
                 revenge: {
                     assets,
-                    modules,
+                    modules: {
+                        find,
+                        filters: {
+                            byProps,
+                            byName,
+                        }
+                    },
                     ui: { settings: sui },
                 },
             } = context
@@ -120,8 +126,8 @@ const plugin = registerPlugin<Storage>(
             // Wait single tick
             await sleep(0)
 
-            const SettingsConstants = modules.findByProps('SETTING_RENDERER_CONFIG')!
-            const SettingsOverviewScreen = modules.findByName<FC, false>('SettingsOverviewScreen', false)!
+            const SettingsConstants = find(byProps('SETTING_RENDERER_CONFIG'))!
+            const SettingsOverviewScreen = find(byName<FC & { name: string }>('SettingsOverviewScreen'), { returnWholeModule: true })!
 
             const originalRendererConfig = SettingsConstants.SETTING_RENDERER_CONFIG as Record<string, RawRowConfig>
             let rendererConfig = originalRendererConfig

--- a/src/plugins/settings/pages/About.tsx
+++ b/src/plugins/settings/pages/About.tsx
@@ -12,8 +12,7 @@ import { ClientInfoModule } from '@revenge-mod/modules/native'
 import PageWrapper from './(Wrapper)'
 
 import { ScrollView } from 'react-native'
-
-import type { ComponentProps } from 'react'
+import { version, type ComponentProps } from 'react'
 
 export default function AboutSettingsPage() {
     const runtimeProps = (HermesInternal as HermesInternalObject).getRuntimeProperties()
@@ -43,7 +42,7 @@ export default function AboutSettingsPage() {
                         {
                             label: 'React',
                             icon: 'Revenge.ReactIcon',
-                            trailing: React.version,
+                            trailing: version,
                         },
                         {
                             label: 'React Native',

--- a/src/plugins/settings/pages/CustomPageRenderer.tsx
+++ b/src/plugins/settings/pages/CustomPageRenderer.tsx
@@ -1,4 +1,5 @@
 import { NavigationNative, type NavigationNativeStackNavigationParamList } from '@revenge-mod/modules/common'
+import { useEffect } from 'react'
 import type { StackScreenProps } from '@react-navigation/stack'
 
 export default function CustomPageRenderer() {
@@ -9,7 +10,7 @@ export default function CustomPageRenderer() {
     const { render: PageComponent, ...args } = route.params
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: We only want to do this once
-    React.useEffect(() => void navigation.setOptions({ ...args }), [])
+    useEffect(() => void navigation.setOptions({ ...args }), [])
 
     return <PageComponent />
 }

--- a/src/plugins/settings/pages/Plugins/components/Illustrations.tsx
+++ b/src/plugins/settings/pages/Plugins/components/Illustrations.tsx
@@ -1,7 +1,7 @@
 import { getAssetIndexByName } from '@revenge-mod/assets'
 import { Button, Stack, Text } from '@revenge-mod/modules/common/components'
 
-import { useContext } from 'react'
+import { createElement, useContext } from 'react'
 import { Image, View } from 'react-native'
 
 import BrowsePluginsButton from './BrowsePluginsButton'
@@ -16,7 +16,7 @@ export function NoPlugins() {
             <Text variant="heading-lg/semibold">No plugins yet!</Text>
             <View style={[styles.centerChildren, { gap: 8 }]}>
                 <BrowsePluginsButton />
-                {React.createElement(ContextMenuComponent!, {
+                {createElement(ContextMenuComponent!, {
                     // biome-ignore lint/correctness/noChildrenProp: This is a valid use case
                     children: props => (
                         <Button

--- a/src/plugins/settings/pages/Plugins/components/PluginListSearchInputAndFilters.tsx
+++ b/src/plugins/settings/pages/Plugins/components/PluginListSearchInputAndFilters.tsx
@@ -3,7 +3,7 @@ import { IconButton } from '@revenge-mod/modules/common/components'
 import { SearchInput } from '@revenge-mod/ui/components'
 import { Show } from '@revenge-mod/utils/components'
 
-import { useContext } from 'react'
+import { createElement, useContext } from 'react'
 import { View } from 'react-native'
 
 import { PluginSettingsPageContext, styles } from './shared'
@@ -22,7 +22,7 @@ export default function PluginListSearchAndFilters() {
                 />
             </View>
             <Show when={ContextMenuComponent}>
-                {React.createElement(ContextMenuComponent!, {
+                {createElement(ContextMenuComponent!, {
                     // biome-ignore lint/correctness/noChildrenProp: This is a valid use case
                     children: props => (
                         <IconButton

--- a/src/plugins/warnings/index.tsx
+++ b/src/plugins/warnings/index.tsx
@@ -3,7 +3,7 @@ import { AlertActionButton, AlertModal } from '@revenge-mod/modules/common/compo
 import { ClientInfoModule } from '@revenge-mod/modules/native'
 import { registerPlugin } from '@revenge-mod/plugins/internals'
 
-const MinimumSupportedBuildNumber = ReactNative.Platform.select({ android: 260000, ios: 69233 })!
+const MinimumSupportedBuildNumber = ReactNative.Platform.select({ android: 263000, ios: 69420 })!
 
 registerPlugin<{
     supportWarningDismissedAt?: number

--- a/src/plugins/warnings/index.tsx
+++ b/src/plugins/warnings/index.tsx
@@ -3,7 +3,7 @@ import { AlertActionButton, AlertModal } from '@revenge-mod/modules/common/compo
 import { ClientInfoModule } from '@revenge-mod/modules/native'
 import { registerPlugin } from '@revenge-mod/plugins/internals'
 
-const MinimumSupportedBuildNumber = ReactNative.Platform.select({ android: 263000, ios: 69420 })!
+const MinimumSupportedBuildNumber = ReactNative.Platform.select({ android: 263000, ios: 69886 })!
 
 registerPlugin<{
     supportWarningDismissedAt?: number
@@ -33,7 +33,7 @@ registerPlugin<{
                         content={
                             // biome-ignore lint/style/useTemplate: I can't see the whole message when not doing concatenation
                             'Revenge does not officially support this build of Discord. Please update to a newer version as some features may not work as expected.\n\n' +
-                            `Supported Builds: 260.0 (${MinimumSupportedBuildNumber}) and above\nYour Build: ${ClientInfoModule.Version} (${ClientInfoModule.Build})`
+                            `Supported Builds: 263.0 (${MinimumSupportedBuildNumber}) and above\nYour Build: ${ClientInfoModule.Version} (${ClientInfoModule.Build})`
                         }
                         actions={
                             <AlertActionButton

--- a/types.d.ts
+++ b/types.d.ts
@@ -20,9 +20,6 @@ declare global {
 
     var revenge: RevengeLibrary
 
-    var React: typeof import('react')
-    var ReactNative: typeof import('react-native')
-
     var __REACT_DEVTOOLS_GLOBAL_HOOK__: unknown | undefined
     var __reactDevTools:
         | {


### PR DESCRIPTION
This PR introduces new finder APIs to `@revenge-mod/modules` and multiple performance improvements.

Here's what the new finder APIs improved:

- Developers can pass `FinderOptions` to a finder in a predictable way
- Removed the concept of raw filters as they can be confusing. You can now pass in `FinderOptions.wildcard` instead.
- Removed boilerplate setup and duplicate code from Revenge Bundle's side
- Types are better represented
- `findByFilePath` is now constant time

Performance-related changes:

- Micro-optimized pre-init code
- Improved module hooking logic
- Improved asset caching

- Use truthy checks rather than `in` checks, as they can be up to 2.2x faster
- Removed useless `patchableModules` cache
- Fixed always-broken cache restoration
- Yield initialized modules before non-initialized ones to defer initializing new modules

- Eagerly find early modules like React & React Native
- Don't find unnecessary modules that aren't needed *yet*
- Only blacklist freezing module on Android

Other changes:

- Bumped supported version in `warnings` plugin
- `@revenge-mod/modules` no longer depends on `@revenge-mod/patcher`
- `@revenge-mod/react` no longer depends on `@revenge-mod/patcher`
- Removed a few globals
- iOS-specific fixes for patching ErrorBoundary has been removed

As always, this PR includes major breaking changes. Developers may migrate from the old finder APIs to the new finder APIs like so:

Old finder APIs:

```tsx
const {
  modules: {
    findByProps,  // (-)
    findByName,   // (-)
    
    // These helper finders stay the same, as they don't necessarily need a filter/use other filters
    findProp,
    findSingleProp,
    findByFilePath,
  }
} = revenge

const React = findByProps<typeof React>('createElement')!  // (-)
const ErrorBoundary = await findByName.async<ErrorBoundaryType>('ErrorBoundary')!  // (-)

const EventEmitter = findProp<EventEmitter>('EventEmitter')!
const TwinButtons = findSingleProp<TwinButtons>('TwinButtons')!
```

New finder APIs:

```tsx
const {
  modules: {
    find,       // (+)
    findAsync,  // (+)
    
    filters: {  // (+)
      byProps,  // (+)
      byName,   // (+)
    },
    
    // These helper finders stay the same, as they don't necessarily need a filter/use other filters
    findProp,
    findSingleProp,
    findByFilePath,
  }
} = revenge

const React = find(byProps<typeof React>('createElement'))!  // (+)
const ErrorBoundary = await findAsync(byName<ErrorBoundary>('ErrorBoundary'))!  // (+)

const EventEmitter = findProp<EventEmitter>('EventEmitter')!
const TwinButtons = findSingleProp<TwinButtons>('TwinButtons')!
```

---

I've also removed the `React` and `ReactNative` globals to avoid polluting the environment. Use the following to access the libraries instead:

```js
const {
  modules: {
    common: { React, ReactNative }
  }
} = revenge
```

> ⚠️ The removal of `globalThis.modules` and `globalThis.revenge` is planned.